### PR TITLE
Implemented Gaussian Smoothing

### DIFF
--- a/FCWTAPI/FCWTAPI.cs
+++ b/FCWTAPI/FCWTAPI.cs
@@ -79,7 +79,15 @@ namespace FCWT.NET
             return fixedResults;
         }
 
+        
         //First element corresponds to the first jagged array dimension (voices), second element corresponds to the second dim (timepoints)
+        /// <summary>
+        /// Method to convert jagged 2D arrays to formal 2D arrays
+        /// In the context of CWT the first dimension represents voices and the second represents timepoints
+        /// </summary>
+        /// <param name="JaggedTwoD"></param>
+        /// <returns></returns>
+        /// <exception cref="IndexOutOfRangeException"></exception>
         public static float[,] ToTwoDArray(float[][] JaggedTwoD)
         {
 

--- a/FCWTAPI/GaussianSmoothing.cs
+++ b/FCWTAPI/GaussianSmoothing.cs
@@ -70,7 +70,7 @@ namespace FCWT.NET
             }
             return res2;
         }
-        private static double ProcessPoint(double[,] matrix, int x, int y, double[,] kernel, int direction)
+        public static double ProcessPoint(double[,] matrix, int x, int y, double[,] kernel, int direction)
         {
             double res = 0;
             int half = kernel.GetLength(0) / 2;

--- a/FCWTAPI/GaussianSmoothing.cs
+++ b/FCWTAPI/GaussianSmoothing.cs
@@ -1,10 +1,18 @@
 ﻿
 namespace FCWT.NET
 {
+    /// <summary>
+    /// Code Derived from http://haishibai.blogspot.com/2009/09/image-processing-c-tutorial-4-gaussian.html
+    /// </summary>
     public class GaussianSmoothing
     {
-        // Code Below is meant to calculate the gaussian kernal in 1D
-        // This first method calculated the kernal based on a single stdev and the desired size of the kernal
+        
+        /// <summary>
+        /// Function to calculate a 1D gaussian kernal 
+        /// </summary>
+        /// <param name="deviation"></param><summary>Standard deviation of the gaussian</summary>
+        /// <param name="size"></param><summary>Size of the 1D gaussian kernal array</summary>
+        /// <returns name="ret"> 1D gaussian kernal array</returns>
         public static double[,] Calculate1DSampleKernel(double deviation, int size)
         {
             double[,] ret = new double[size, 1];
@@ -17,17 +25,30 @@ namespace FCWT.NET
             }
             return ret;
         }
-        // Calculates 1D kernal based on stdev alone setting radius to 3*stdev + 1
+        /// <summary>
+        /// Overload of Calculat1DSampleKernal which automatically sets the array size of the kernal to Ceiling(deviation * 3) * 2 + 1
+        /// </summary>
+        /// <param name="deviation"></param>
+        /// <returns></returns>
         public static double[,] Calculate1DSampleKernel(double deviation)
         {
             int size = (int)Math.Ceiling(deviation * 3) * 2 + 1;
             return Calculate1DSampleKernel(deviation, size);
         }
-        // Calculates a normalized 1d sample kernal 
+        /// <summary>
+        /// Calculates a normalized 1D gaussian kernal
+        /// </summary>
+        /// <param name="deviation"></param>
+        /// <returns></returns>
         public static double[,] CalculateNormalized1DSampleKernel(double deviation)
         {
             return NormalizeMatrix(Calculate1DSampleKernel(deviation));
         }
+        /// <summary>
+        /// Normalizes any double[,] array such that the sum of all elements is equal to 1
+        /// </summary>
+        /// <param name="matrix"> double[,] array to be normalized </param>
+        /// <returns name="ret"> normalized double[,] array</returns>
         public static double[,] NormalizeMatrix(double[,] matrix)
         {
             double[,] ret = new double[matrix.GetLength(0), matrix.GetLength(1)];
@@ -47,41 +68,47 @@ namespace FCWT.NET
             }
             return ret;
         }
-        // Calculates a gaussian convolution from a given double matrix splitting the calc into
-        // x and y direction convolution are calculated separately
+        /// <summary>
+        /// Method to preform the 2D gaussian smoothing
+        /// This method applies the smoothing operation by first smoothing in the x direction, then the y direction using a symmetric 1D kernal
+        /// </summary>
+        /// <param name="matrix">double[,] array to be smoothed </param>
+        /// <param name="deviation">deviation of the gaussian smoothing function</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException">Exception to prevent input matrix from being smaller than the convolving function</exception>
         public static double[,] GaussianConvolution(double[,] matrix, double deviation)
         {
             if (matrix.GetLength(0) < (deviation * 6 + 1) || matrix.GetLength(1) < (deviation * 6 + 1))
             {
                 throw new ArgumentException("Matrix may not be smaller than the convoluting gaussian kernal");
             }
-            double[,] kernel = CalculateNormalized1DSampleKernel(deviation);
+            double[,] kernel = CalculateNormalized1DSampleKernel(deviation); // Calculates the 1D kernal to be used for smoothing
             double[,] res1 = new double[matrix.GetLength(0), matrix.GetLength(1)];
             double[,] res2 = new double[matrix.GetLength(0), matrix.GetLength(1)];
-            //x-direction
+            //x-direction smoothing
             for (int i = 0; i < matrix.GetLength(0); i++)
             {
                 // Calculates each point in the x direction
                 for (int j = 0; j < matrix.GetLength(1); j++)
                     res1[i, j] = ProcessPoint(matrix, i, j, kernel, 0);
             }
-            //y-direction
+            //y-direction smoothing
             for (int i = 0; i < matrix.GetLength(0); i++)
             {
-                //Calculates each point in the y direction
+                //Calculates each point in the y direction from the x smoothed array res 1
                 for (int j = 0; j < matrix.GetLength(1); j++)
                     res2[i, j] = ProcessPoint(res1, i, j, kernel, 1);
             }
             return res2;
         }
         /// <summary>
-        /// 
+        /// Method to process each individual point of a given double[,] array 
         /// </summary>
-        /// <param name="matrix"></param>
-        /// <param name="x"></param>
-        /// <param name="y"></param>
-        /// <param name="kernel"></param>
-        /// <param name="direction"></param>
+        /// <param name="matrix"> double[,] array meant to be processed</param>
+        /// <param name="x">x coordinate of the point being processed</param>
+        /// <param name="y">y coordinate of the point being processed</param>
+        /// <param name="kernel">Normalized 1D gaussian kernal</param>
+        /// <param name="direction">Direction to apply the gausian kernal to a given point 0 corresponds to x, 1 corresponds to y</param>
         /// <returns></returns>
         public static double ProcessPoint(double[,] matrix, int x, int y, double[,] kernel, int direction)
         {

--- a/FCWTAPI/GaussianSmoothing.cs
+++ b/FCWTAPI/GaussianSmoothing.cs
@@ -1,0 +1,89 @@
+﻿
+namespace FCWT.NET
+{
+    public class GaussianSmoothing
+    {
+        // Code Below is meant to calculate the gaussian kernal in 1D
+        // This first method calculated the kernal based on a single stdev and the desired size of the kernal
+        public static double[,] Calculate1DSampleKernel(double deviation, int size)
+        {
+            double[,] ret = new double[size, 1];
+            double sum = 0;
+            int half = size / 2;
+            for (int i = 0; i < size; i++)
+            {
+                ret[i, 0] = 1 / (Math.Sqrt(2 * Math.PI) * deviation) * Math.Exp(-(i - half) * (i - half) / (2 * deviation * deviation));
+                sum += ret[i, 0];
+            }
+            return ret;
+        }
+        // Calculates 1D kernal based on stdev alone setting radius to 3*stdev + 1
+        public static double[,] Calculate1DSampleKernel(double deviation)
+        {
+            int size = (int)Math.Ceiling(deviation * 3) * 2 + 1;
+            return Calculate1DSampleKernel(deviation, size);
+        }
+        // Calculates a normalized 1d sample kernal 
+        public static double[,] CalculateNormalized1DSampleKernel(double deviation)
+        {
+            return NormalizeMatrix(Calculate1DSampleKernel(deviation));
+        }
+        public static double[,] NormalizeMatrix(double[,] matrix)
+        {
+            double[,] ret = new double[matrix.GetLength(0), matrix.GetLength(1)];
+            double sum = 0;
+            for (int i = 0; i < ret.GetLength(0); i++)
+            {
+                for (int j = 0; j < ret.GetLength(1); j++)
+                    sum += matrix[i, j];
+            }
+            if (sum != 0)
+            {
+                for (int i = 0; i < ret.GetLength(0); i++)
+                {
+                    for (int j = 0; j < ret.GetLength(1); j++)
+                        ret[i, j] = matrix[i, j] / sum;
+                }
+            }
+            return ret;
+        }
+        // Calculates a gaussian convolution from a given double matrix splitting the calc into
+        // x and y direction convolution are calculated separately
+        public static double[,] GaussianConvolution(double[,] matrix, double deviation)
+        {
+            double[,] kernel = CalculateNormalized1DSampleKernel(deviation);
+            double[,] res1 = new double[matrix.GetLength(0), matrix.GetLength(1)];
+            double[,] res2 = new double[matrix.GetLength(0), matrix.GetLength(1)];
+            //x-direction
+            for (int i = 0; i < matrix.GetLength(0); i++)
+            {
+                // Calculates each point in the x direction
+                for (int j = 0; j < matrix.GetLength(1); j++)
+                    res1[i, j] = ProcessPoint(matrix, i, j, kernel, 0);
+            }
+            //y-direction
+            for (int i = 0; i < matrix.GetLength(0); i++)
+            {
+                //Calculates each point in the y direction
+                for (int j = 0; j < matrix.GetLength(1); j++)
+                    res2[i, j] = ProcessPoint(res1, i, j, kernel, 1);
+            }
+            return res2;
+        }
+        private static double ProcessPoint(double[,] matrix, int x, int y, double[,] kernel, int direction)
+        {
+            double res = 0;
+            int half = kernel.GetLength(0) / 2;
+            for (int i = 0; i < kernel.GetLength(0); i++)
+            {
+                int cox = direction == 0 ? x + i - half : x; // Set cox
+                int coy = direction == 1 ? y + i - half : y;
+                if (cox >= 0 && cox < matrix.GetLength(0) && coy >= 0 && coy < matrix.GetLength(1))
+                {
+                    res += matrix[cox, coy] * kernel[i, 0];
+                }
+            }
+            return res;
+        }
+    }
+}

--- a/FCWTAPI/GaussianSmoothing.cs
+++ b/FCWTAPI/GaussianSmoothing.cs
@@ -51,6 +51,10 @@ namespace FCWT.NET
         // x and y direction convolution are calculated separately
         public static double[,] GaussianConvolution(double[,] matrix, double deviation)
         {
+            if (matrix.GetLength(0) < (deviation * 6 + 1) || matrix.GetLength(1) < (deviation * 6 + 1))
+            {
+                throw new ArgumentException("Matrix may not be smaller than the convoluting gaussian kernal");
+            }
             double[,] kernel = CalculateNormalized1DSampleKernel(deviation);
             double[,] res1 = new double[matrix.GetLength(0), matrix.GetLength(1)];
             double[,] res2 = new double[matrix.GetLength(0), matrix.GetLength(1)];
@@ -70,17 +74,28 @@ namespace FCWT.NET
             }
             return res2;
         }
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="matrix"></param>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <param name="kernel"></param>
+        /// <param name="direction"></param>
+        /// <returns></returns>
         public static double ProcessPoint(double[,] matrix, int x, int y, double[,] kernel, int direction)
         {
             double res = 0;
             int half = kernel.GetLength(0) / 2;
+
             for (int i = 0; i < kernel.GetLength(0); i++)
             {
-                int cox = direction == 0 ? x + i - half : x; // Set cox
-                int coy = direction == 1 ? y + i - half : y;
-                if (cox >= 0 && cox < matrix.GetLength(0) && coy >= 0 && coy < matrix.GetLength(1))
+                int cox = direction == 0 ? x + i - half : x; // Sets the x coordinate of the point being multiplied by the kernal to contribute to the final value of the point being processed
+                int coy = direction == 1 ? y + i - half : y; // Sets the y coordinate of the point being multiplied by the kernal to contribute to the final value of the point being processed
+                // The direction determines which direction the kernal is applied in for each point
+                if (cox >= 0 && cox < matrix.GetLength(0) && coy >= 0 && coy < matrix.GetLength(1)) // If the kernal extends beyond the matrix, those values are treated as zero leading to mild "darkening"
                 {
-                    res += matrix[cox, coy] * kernel[i, 0];
+                    res += matrix[cox, coy] * kernel[i, 0]; // Sums up the final value of the kernal
                 }
             }
             return res;

--- a/TestFCWTAPI/UnitTest1.cs
+++ b/TestFCWTAPI/UnitTest1.cs
@@ -158,13 +158,13 @@ namespace TestFCWTAPI
         public void TestNormalizeMatrix()
         {
             double[,] unnormalizedMatrix = new double[,] { { 5, 7, 9 }, { 3, 4, 7 }, { 5, 6, 7 } };
-            double unnormalizedRatio1 = unnormalizedMatrix[0, 2] / unnormalizedMatrix[1, 3];
-            double unnormalizedRatio2 = unnormalizedMatrix[1, 2] / unnormalizedMatrix[2, 3];
+            double unnormalizedRatio1 = unnormalizedMatrix[0, 2] / unnormalizedMatrix[1, 2];
+            double unnormalizedRatio2 = unnormalizedMatrix[1, 2] / unnormalizedMatrix[2, 2];
             double[,] normalizedMatrix = GaussianSmoothing.NormalizeMatrix(unnormalizedMatrix);
-            double normalizedRatio1 = normalizedMatrix[0, 2] / normalizedMatrix[1, 3];
-            double normalizedRatio2 = normalizedMatrix[1, 2] / normalizedMatrix[2, 3];
-            Assert.AreEqual(normalizedRatio1, unnormalizedRatio1);
-            Assert.AreEqual(normalizedRatio2, unnormalizedRatio2);
+            double normalizedRatio1 = normalizedMatrix[0, 2] / normalizedMatrix[1, 2];
+            double normalizedRatio2 = normalizedMatrix[1, 2] / normalizedMatrix[2, 2];
+            Assert.AreEqual(normalizedRatio1, unnormalizedRatio1, 0.001);
+            Assert.AreEqual(normalizedRatio2, unnormalizedRatio2, 0.001);
             double normalizedSum = 0;
             for(int i = 0; i < unnormalizedMatrix.GetLength(0); i++)
             {
@@ -173,7 +173,7 @@ namespace TestFCWTAPI
                     normalizedSum = normalizedSum + normalizedMatrix[i, j];
                 }
             }
-            Assert.AreEqual(normalizedSum, unnormalizedRatio1, 0.001);
+            Assert.AreEqual(normalizedSum, 1, 0.001);
             
         }
         [Test]
@@ -183,20 +183,19 @@ namespace TestFCWTAPI
             var pointArray = new (int, int, double)[]
             {
                 (8, 8, 1),
-                (27, 8, 1),
-                (43, 2, 1),
-                (50, 50, 1)
+                (27, 8, -1),
+                (2, 43, 1),
+                (49, 49, 1)
             };
-            for(int i = 0; i < 51; i++)
+            for(int i = 0; i < 50; i++)
             {
                 for (int j = 0; j < 50; j++)
                 {
-                    for (int t = 0; t < 50; t++)
+                    for (int t = 0; t < 4; t++)
                         if (i == pointArray[t].Item1 && j == pointArray[t].Item2)
                         {
                             test2DArray[i, j] = pointArray[t].Item3;
                         }
-                        else { test2DArray[i, j] = 0; }
                 }
                 
             }
@@ -206,6 +205,7 @@ namespace TestFCWTAPI
             {
                 valueArray[p] = GaussianSmoothing.ProcessPoint(test2DArray, pointArray[p].Item1, pointArray[p].Item2, test1dKernal, 0);
             }
+            int numberOne = 1;
         }
     }
 

--- a/TestFCWTAPI/UnitTest1.cs
+++ b/TestFCWTAPI/UnitTest1.cs
@@ -11,20 +11,20 @@ namespace TestFCWTAPI
         [SetUp]
         public void Setup()
         {
-            
+
         }
         [Test]
         public void TestFCWT()
         {
             double[] testValues = new double[1000];
-            double constant = 1D / 1000D * 2D * Math.PI; 
+            double constant = 1D / 1000D * 2D * Math.PI;
             for (int i = 0; i < 1000; i++)
             {
-                double val = (double)i * constant; 
+                double val = (double)i * constant;
                 testValues[i] = val;
             }
             double[] cosine = FunctionGenerator.TransformValues(testValues, FunctionGenerator.GenerateCosineWave);
-            float[][] results = FCWTAPI.CWT(cosine, 1, 6, 200, (float)(2 * Math.PI), 4, false); 
+            float[][] results = FCWTAPI.CWT(cosine, 1, 6, 200, (float)(2 * Math.PI), 4, false);
             Assert.AreEqual(200 * 6 * 2, results.GetLength(0));
         }
         [Test]
@@ -32,7 +32,7 @@ namespace TestFCWTAPI
         {
             double[] testArray = new double[] { 0D, 1D, 2D };
             float[] fArray = FCWTAPI.ConvertDoubleToFloat(testArray);
-            Assert.AreEqual((float)testArray[1], fArray[1]); 
+            Assert.AreEqual((float)testArray[1], fArray[1]);
         }
         [Test]
         public void TestFixOutputArray()
@@ -40,11 +40,11 @@ namespace TestFCWTAPI
             float[] testArray = new float[]
             {1F, 2F, 3F,
             4F, 5F, 6F,
-            7F, 8F, 9F, 
+            7F, 8F, 9F,
             10F, 11F, 12F};
 
             float[][] outputArray = FCWTAPI.FixOutputArray(testArray, 3, 1, 2);
-            Assert.AreEqual(4, outputArray.GetLength(0)); 
+            Assert.AreEqual(4, outputArray.GetLength(0));
         }
 
 
@@ -81,7 +81,7 @@ namespace TestFCWTAPI
                 new float[] {11, 12, 13, 14, 15, 16, 22}
             };
             Assert.Throws<IndexOutOfRangeException>(() => FCWTAPI.ToTwoDArray(badJaggedArray3));
-
+        }
         [Test]
         public void TestSplitIntoRealAndImaginary()
         {
@@ -94,7 +94,7 @@ namespace TestFCWTAPI
             FCWTAPI.SplitIntoRealAndImaginary(testArray, out float[][] realArray,
                 out float[][] imaginaryArray);
             Assert.AreEqual(4, realArray[0].Length);
-            Assert.AreEqual(4, imaginaryArray[0].Length); 
+            Assert.AreEqual(4, imaginaryArray[0].Length);
         }
         [Test]
         public void TestCalculatePhase()
@@ -107,7 +107,7 @@ namespace TestFCWTAPI
 
             float[][] phaseArray = FCWTAPI.CalculatePhase(testArray, testArray);
 
-            Assert.AreEqual(1.273, phaseArray[0][0], 0.001); 
+            Assert.AreEqual(1.273, phaseArray[0][0], 0.001);
         }
         [Test]
         public void TestCalculateModulus()
@@ -120,11 +120,11 @@ namespace TestFCWTAPI
 
             float[][] modArray = FCWTAPI.CalculateModulus(testArray, testArray);
             Console.WriteLine(string.Join("; ", modArray[0].AsEnumerable()));
-            Assert.AreEqual(1.41421, modArray[0][0], 0.001); 
+            Assert.AreEqual(1.41421, modArray[0][0], 0.001);
 
         }
         [Test]
-        public void testPreformCWT()
+        public void TestPreformCWT()
         {
             double[] testValues = new double[1000];
             double constant = 1D / 1000D * 2D * Math.PI;
@@ -139,6 +139,76 @@ namespace TestFCWTAPI
             Assert.AreEqual(cosineCWT.OutputCWT.GetLength(0), 200 * 6 * 2);
             Assert.AreEqual(cosineCWT.OutputCWT.GetLength(1), 1000);
         }
-
+        [Test]
+        public void TestCalculateSampleKernal()
+        {
+            double gaussDeviation = 1;
+            int gaussSize = 7;
+            int checkOne = 1;
+            double checkPoint1 = 1 / (Math.Sqrt(2 * Math.PI) * 1) * Math.Exp(-(checkOne - gaussSize/2) * (checkOne - gaussSize/2) / (2 * gaussDeviation * gaussDeviation));
+            int checkTwo = 5;
+            double checkPoint2 = 1 / (Math.Sqrt(2 * Math.PI) * 1) * Math.Exp(-(checkTwo - gaussSize / 2) * (checkTwo - gaussSize / 2) / (2 * gaussDeviation * gaussDeviation));
+            double[,] deviationKernal = GaussianSmoothing.Calculate1DSampleKernel(gaussDeviation);
+            double[,] allparamsKernal = GaussianSmoothing.Calculate1DSampleKernel(gaussDeviation, gaussSize);
+            Assert.AreEqual(deviationKernal, allparamsKernal);
+            Assert.AreEqual(checkPoint1, deviationKernal[1, 0]);
+            Assert.AreEqual(checkPoint2, deviationKernal[5, 0]);
+        }
+        [Test]
+        public void TestNormalizeMatrix()
+        {
+            double[,] unnormalizedMatrix = new double[,] { { 5, 7, 9 }, { 3, 4, 7 }, { 5, 6, 7 } };
+            double unnormalizedRatio1 = unnormalizedMatrix[0, 2] / unnormalizedMatrix[1, 3];
+            double unnormalizedRatio2 = unnormalizedMatrix[1, 2] / unnormalizedMatrix[2, 3];
+            double[,] normalizedMatrix = GaussianSmoothing.NormalizeMatrix(unnormalizedMatrix);
+            double normalizedRatio1 = normalizedMatrix[0, 2] / normalizedMatrix[1, 3];
+            double normalizedRatio2 = normalizedMatrix[1, 2] / normalizedMatrix[2, 3];
+            Assert.AreEqual(normalizedRatio1, unnormalizedRatio1);
+            Assert.AreEqual(normalizedRatio2, unnormalizedRatio2);
+            double normalizedSum = 0;
+            for(int i = 0; i < unnormalizedMatrix.GetLength(0); i++)
+            {
+                for(int j = 0; j < unnormalizedMatrix.GetLength(1); j++)
+                {
+                    normalizedSum = normalizedSum + normalizedMatrix[i, j];
+                }
+            }
+            Assert.AreEqual(normalizedSum, unnormalizedRatio1, 0.001);
+            
+        }
+        [Test]
+        public void TestProcessPoint()
+        {
+            double[,] test2DArray = new double[51, 51];
+            var pointArray = new (int, int, double)[]
+            {
+                (8, 8, 1),
+                (27, 8, 1),
+                (43, 2, 1),
+                (50, 50, 1)
+            };
+            for(int i = 0; i < 51; i++)
+            {
+                for (int j = 0; j < 50; j++)
+                {
+                    for (int t = 0; t < 50; t++)
+                        if (i == pointArray[t].Item1 && j == pointArray[t].Item2)
+                        {
+                            test2DArray[i, j] = pointArray[t].Item3;
+                        }
+                        else { test2DArray[i, j] = 0; }
+                }
+                
+            }
+            double[] valueArray = new double[4];
+            double[,] test1dKernal = GaussianSmoothing.CalculateNormalized1DSampleKernel(1);
+            for (int p = 0; p < 4; p++)
+            {
+                valueArray[p] = GaussianSmoothing.ProcessPoint(test2DArray, pointArray[p].Item1, pointArray[p].Item2, test1dKernal, 0);
+            }
+        }
     }
+
+
+    
 }

--- a/TestFCWTAPI/UnitTest1.cs
+++ b/TestFCWTAPI/UnitTest1.cs
@@ -180,14 +180,14 @@ namespace TestFCWTAPI
         public void TestProcessPoint()
         {
             double[,] test2DArray = new double[51, 51];
-            var pointArray = new (int, int, double)[]
+            var pointArray = new (int, int, double)[] // List of points to add to a test array
             {
-                (8, 8, 1),
-                (27, 8, -1),
-                (2, 43, 1),
-                (50, 50, 1)
+                (8, 8, 1), // Generic point
+                (27, 8, -1), // Sample point with a negative value
+                (2, 43, 1), // Sample point next to an edge
+                (50, 50, 1) // Sample point in a corner
             };
-            var neighborArray = new (int, int)[]
+            var neighborArray = new (int, int)[] // Generates a list of cooridinates to points adjacent to the points in pointArray on the x direction
             {
                 (7, 8),
                 (26, 8),
@@ -195,7 +195,8 @@ namespace TestFCWTAPI
                 (49, 50)
             };
 
-            for(int i = 0; i < 51; i++)
+            // Generates a 2D array containing all points from pointArray
+            for (int i = 0; i < 51; i++)
             {
                 for (int j = 0; j < 51; j++)
                 {
@@ -207,14 +208,15 @@ namespace TestFCWTAPI
                 }
                 
             }
-            double[] valueArray = new double[4];
-            double[] neighborValueArray = new double[4];
-            double testDeviation = 2;
-            int testSize = 7;
-            double[,] test1dKernal = GaussianSmoothing.CalculateNormalized1DSampleKernel(testDeviation);
-            double gaussPoint4 = 1 / (Math.Sqrt(2 * Math.PI) * testDeviation) * Math.Exp(-(3 - testSize / 2) * (3 - testSize / 2) / (2 * testDeviation * testDeviation));
-            double gaussPoint3 = 1 / (Math.Sqrt(2 * Math.PI) * testDeviation) * Math.Exp(-(2 - testSize / 2) * (2 - testSize / 2) / (2 * testDeviation * testDeviation));
-            for (int p = 0; p < 4; p++)
+
+            double[] valueArray = new double[4]; // Array to store transformed values of the pointArray points
+            double[] neighborValueArray = new double[4]; // Array to store transformed values of the neighborArray points
+            double testDeviation = 1; //Deviation of the guassian used
+            int testSize = 7; // Size of the gaussian used
+            double[,] test1dKernal = GaussianSmoothing.CalculateNormalized1DSampleKernel(testDeviation); // 1D gaussian kernal generated to test this
+            double gaussPoint4 = 1 / (Math.Sqrt(2 * Math.PI) * testDeviation) * Math.Exp(-(3 - testSize / 2) * (3 - testSize / 2) / (2 * testDeviation * testDeviation)); // Point at the center of the gaussian
+            double gaussPoint3 = 1 / (Math.Sqrt(2 * Math.PI) * testDeviation) * Math.Exp(-(2 - testSize / 2) * (2 - testSize / 2) / (2 * testDeviation * testDeviation)); // Point 1 unit off center of the gaussian
+            for (int p = 0; p < 4; p++) //Checks that all values from the Process point function are what they should be
             {
                 valueArray[p] = GaussianSmoothing.ProcessPoint(test2DArray, pointArray[p].Item1, pointArray[p].Item2, test1dKernal, 0);
                 neighborValueArray[p] = GaussianSmoothing.ProcessPoint(test2DArray, neighborArray[p].Item1, neighborArray[p].Item2, test1dKernal, 0);
@@ -242,21 +244,28 @@ namespace TestFCWTAPI
             };
             Assert.Throws<ArgumentException>(() => GaussianSmoothing.GaussianConvolution(invalid2DArray, 1));
             double[,] test2DArray = new double[51, 51];
-            var pointArray = new (int, int, double)[]
+            var pointArray = new (int, int, double)[] // List of points to add to a test array
             {
-                (8, 8, 1),
-                (27, 8, -1),
-                (2, 43, 1),
-                (50, 50, 1)
+                (8, 8, 1), // Generic point
+                (27, 8, -1), // Sample point with a negative value
+                (2, 43, 1), // Sample point next to an edge
+                (50, 50, 1) // Sample point in a corner
             };
-            var neighborArray = new (int, int)[]
+            var adjacentArray = new (int, int)[] // Generates a list of cooridinates to points adjacent to the points in pointArray
             {
                 (7, 8),
-                (26, 8),
+                (27, 9),
                 (1, 43),
-                (49, 50)
+                (50, 49)
             };
-
+            var diagonalArray = new (int, int)[] // Generates a list of cooridinates to points diagonal to the points in pointArray
+            {
+                (9, 9),
+                (28, 9),
+                (3, 44),
+                (49, 49)
+            };
+            // Generates a 2D array containing all points from pointArray
             for (int i = 0; i < 51; i++)
             {
                 for (int j = 0; j < 51; j++)
@@ -269,9 +278,19 @@ namespace TestFCWTAPI
                 }
 
             }
-            double testDeviation = 1;
+            double testDeviation = 1; // Deviation of our test 2d gaussian
             double centerPoint = 1 / (2 * Math.PI * testDeviation);
-
+            double adjacentPoint = 1 / (2 * Math.PI * testDeviation) * Math.Exp(-(1 * 1) / (2 * testDeviation * testDeviation)); // Calculates a point 1 off from the center of the 2d gaussian in any direction
+            double diagonalPoint = 1 / (2 * Math.PI * testDeviation) * Math.Exp(- 2 / (2 * testDeviation * testDeviation)); // Calculates a point 1 off from the center in in x and y direction
+            double[,] testBlurredArray = GaussianSmoothing.GaussianConvolution(test2DArray, testDeviation); // Calculats the gaussian convolution of our test 2d gaussian with tesd2DArray
+            for (int p = 0; p < 4; p++)
+            {
+                Assert.AreEqual(centerPoint * pointArray[p].Item3, testBlurredArray[pointArray[p].Item1, pointArray[p].Item2], 0.001); // Checks all the center point values for correctness
+                Assert.AreEqual(adjacentPoint * pointArray[p].Item3, testBlurredArray[adjacentArray[p].Item1, adjacentArray[p].Item2], 0.001); // Checks all the adjacent point values for correctness
+                Assert.AreEqual(diagonalPoint * pointArray[p].Item3, testBlurredArray[diagonalArray[p].Item1, diagonalArray[p].Item2], 0.001); // Checks all the diagonal point values for correctness
+            }
+            // Note: this guassian smoothing function does not preserve the the total "intensity" of the array it operates on, there exists a sort of edge darkening that should be fixed later
+            // The unit test for this new function should include a module to ensure that the sum of the original array equals the sum of the blurred array
 
         }
     }

--- a/TestFCWTAPI/UnitTest1.cs
+++ b/TestFCWTAPI/UnitTest1.cs
@@ -185,11 +185,19 @@ namespace TestFCWTAPI
                 (8, 8, 1),
                 (27, 8, -1),
                 (2, 43, 1),
-                (49, 49, 1)
+                (50, 50, 1)
             };
-            for(int i = 0; i < 50; i++)
+            var neighborArray = new (int, int)[]
             {
-                for (int j = 0; j < 50; j++)
+                (7, 8),
+                (26, 8),
+                (1, 43),
+                (49, 50)
+            };
+
+            for(int i = 0; i < 51; i++)
+            {
+                for (int j = 0; j < 51; j++)
                 {
                     for (int t = 0; t < 4; t++)
                         if (i == pointArray[t].Item1 && j == pointArray[t].Item2)
@@ -200,12 +208,71 @@ namespace TestFCWTAPI
                 
             }
             double[] valueArray = new double[4];
-            double[,] test1dKernal = GaussianSmoothing.CalculateNormalized1DSampleKernel(1);
+            double[] neighborValueArray = new double[4];
+            double testDeviation = 2;
+            int testSize = 7;
+            double[,] test1dKernal = GaussianSmoothing.CalculateNormalized1DSampleKernel(testDeviation);
+            double gaussPoint4 = 1 / (Math.Sqrt(2 * Math.PI) * testDeviation) * Math.Exp(-(3 - testSize / 2) * (3 - testSize / 2) / (2 * testDeviation * testDeviation));
+            double gaussPoint3 = 1 / (Math.Sqrt(2 * Math.PI) * testDeviation) * Math.Exp(-(2 - testSize / 2) * (2 - testSize / 2) / (2 * testDeviation * testDeviation));
             for (int p = 0; p < 4; p++)
             {
                 valueArray[p] = GaussianSmoothing.ProcessPoint(test2DArray, pointArray[p].Item1, pointArray[p].Item2, test1dKernal, 0);
+                neighborValueArray[p] = GaussianSmoothing.ProcessPoint(test2DArray, neighborArray[p].Item1, neighborArray[p].Item2, test1dKernal, 0);
+                if( p != 1)
+                {
+                    Assert.AreEqual(gaussPoint4, valueArray[p], 0.01);
+                    Assert.AreEqual(gaussPoint3, neighborValueArray[p], 0.01);
+                }
+                else
+                {
+                    Assert.AreEqual(gaussPoint4 * -1, valueArray[p], 0.01);
+                    Assert.AreEqual(gaussPoint3 * -1, neighborValueArray[p], 0.01);
+                }
+
             }
-            int numberOne = 1;
+        }
+        [Test]
+        public void TestGaussianConvolution()
+        {
+            double[,] invalid2DArray = new double[,]
+            {
+                {1, 2, 3, 4, 5 },
+                {4, 5, 6, 7, 8 },
+                {9, 10, 11, 12, 13 },
+            };
+            Assert.Throws<ArgumentException>(() => GaussianSmoothing.GaussianConvolution(invalid2DArray, 1));
+            double[,] test2DArray = new double[51, 51];
+            var pointArray = new (int, int, double)[]
+            {
+                (8, 8, 1),
+                (27, 8, -1),
+                (2, 43, 1),
+                (50, 50, 1)
+            };
+            var neighborArray = new (int, int)[]
+            {
+                (7, 8),
+                (26, 8),
+                (1, 43),
+                (49, 50)
+            };
+
+            for (int i = 0; i < 51; i++)
+            {
+                for (int j = 0; j < 51; j++)
+                {
+                    for (int t = 0; t < 4; t++)
+                        if (i == pointArray[t].Item1 && j == pointArray[t].Item2)
+                        {
+                            test2DArray[i, j] = pointArray[t].Item3;
+                        }
+                }
+
+            }
+            double testDeviation = 1;
+            double centerPoint = 1 / (2 * Math.PI * testDeviation);
+
+
         }
     }
 


### PR DESCRIPTION
This is a vanilla version of the gaussian smoothing algorithm. There is still some work to do on it mainly:
1. Dealing with edge darkening as we discussed
2. Addressing the issue of the fact that features and possibly noise at different voices change in size, potentially requiring a different 2D gaussian to smooth the top of a CWT compared to the bottom. A future fix for this could include basing the stdev of the gaussian in the x and y direction on the dimensions of a Heisenberg box in a particular frequency group since no features will be smaller than that.