### PR TITLE
CWT frequencies, convert frequency range to axis indices

### DIFF
--- a/FCWTAPI/CWTFrequencies.cs
+++ b/FCWTAPI/CWTFrequencies.cs
@@ -10,11 +10,12 @@ namespace FCWTNET
     {
         public double[]? WaveletCenterFrequencies { get; private set; }
         public int Length { get; private set; }
-        
-        public CWTFrequencies(double[] centerFrequencies)
+        public int Pnbvoice { get; private set; }
+        public CWTFrequencies(double[] centerFrequencies, int pnbvoice)
         {
             WaveletCenterFrequencies = centerFrequencies;
             Length = centerFrequencies.Length;
+            Pnbvoice = pnbvoice;
         }
         public CWTFrequencies()
         {
@@ -37,6 +38,59 @@ namespace FCWTNET
                 mzValues[i] = calibrationCoefficient / (WaveletCenterFrequencies[i] * WaveletCenterFrequencies[i]); 
             }
             return mzValues; 
+        }
+        public (int, int) CalculateIndicesForFrequencyRange(double startFrequency, double endFrequency)
+        {          
+
+            if (WaveletCenterFrequencies == null)
+            {
+                throw new ArgumentNullException(nameof(WaveletCenterFrequencies), "WaveletCenterFrequencies cannot be null");
+            }
+            if (WaveletCenterFrequencies[0] > startFrequency)
+            {
+                throw new ArgumentException(nameof(startFrequency), "startFrequency cannot be less than the minimum frequency");
+            }
+            if (startFrequency >= endFrequency)
+            {
+                throw new ArgumentException(nameof(endFrequency), "endFrequency must be greater than startFrequency");
+            }
+            if (WaveletCenterFrequencies[^1] < endFrequency)
+            {
+                throw new ArgumentException(nameof(endFrequency), "endFrequency must not be greater than the maximum CWT frequency");
+            }
+            if (WaveletCenterFrequencies[^2] <= startFrequency)
+            {
+                return (WaveletCenterFrequencies.Length - 2, WaveletCenterFrequencies.Length - 1);
+            }
+            else
+            {
+                int rawStartIndex = Array.BinarySearch(WaveletCenterFrequencies, startFrequency);
+                double axisStartFrequency;
+                int axisStartIndex;
+                int positiveStartIndex;
+                if (rawStartIndex < 0)
+                {
+                    positiveStartIndex = rawStartIndex * -1 - 1;
+                }
+                else
+                {
+                    positiveStartIndex = rawStartIndex;
+                }
+
+                if (WaveletCenterFrequencies[positiveStartIndex] > startFrequency)
+                {
+                    axisStartIndex = positiveStartIndex - 1;
+                }
+                else
+                {
+                    axisStartIndex = positiveStartIndex;
+                }
+                axisStartFrequency = WaveletCenterFrequencies[positiveStartIndex];
+                double deltaA = 1 / Convert.ToDouble(Pnbvoice);
+                int numFreqs = Convert.ToInt32(Math.Ceiling(Math.Log2(endFrequency / axisStartFrequency) / deltaA));
+                int axisEndIndex = axisStartIndex + numFreqs;
+                return (axisStartIndex, axisEndIndex);
+            }
         }
         public void CalculateFrequencyFromScale()
         {

--- a/FCWTAPI/CWTObject.cs
+++ b/FCWTAPI/CWTObject.cs
@@ -209,11 +209,11 @@ namespace FCWTNET
             int octaveNum = 1 + Pendoctave - Psoctave;
             double deltaA = 1 / Convert.ToDouble(Pnbvoice);
             double[] freqArray = new double[octaveNum * Pnbvoice];
-            for (int i = 0 ; i < octaveNum * Pnbvoice; i++)
+            for (int i = 1 ; i <= octaveNum * Pnbvoice; i++)
             {
-                freqArray[i] = C0 / Math.Pow(2, (1 + (i + 1) * deltaA));
+                freqArray[^i] = C0 / Math.Pow(2, (1 + (i + 1) * deltaA));
             }
-            FrequencyAxis = new CWTFrequencies(freqArray);            
+            FrequencyAxis = new CWTFrequencies(freqArray, Pnbvoice, C0);            
         }
         public void CalculateTimeAxis()
         {

--- a/TestFCWTAPI/CWTObjectTests.cs
+++ b/TestFCWTAPI/CWTObjectTests.cs
@@ -94,23 +94,6 @@ namespace TestFCWTAPI
             Assert.AreEqual(testPoint, testPhase[32, 32], 0.001);
         }
         [Test]
-        public static void TestCalculateFrequencyAxis()
-        {
-            double[] testValues = new double[1000];
-            double constant = 1D / 1000D * 2D * Math.PI;
-            for (int i = 0; i < 1000; i++)
-            {
-                double val = (double)i * constant;
-                testValues[i] = val;
-            }
-            double[] cosine = FunctionGenerator.TransformValues(testValues, FunctionGenerator.GenerateCosineWave);
-            CWTObject cosCWT = new(cosine, 1, 6, 200, (float)(2 * Math.PI), 4, false);
-            cosCWT.CalculateFrequencyAxis();
-            cosCWT.PerformCWT();
-            Assert.AreEqual(cosCWT.GetFrequencyAtIndex(4), (2 * Math.PI) / Math.Pow(2, 1.025), 0.001);
-            Assert.AreEqual(cosCWT.OutputCWT.GetLength(0) / 2, cosCWT.FrequencyAxis.Length);
-        }
-        [Test]
         public static void TestCalculateTimeAxis()
         {
             double[] testValues = new double[1000];

--- a/TestFCWTAPI/TestCWTFrequencies.cs
+++ b/TestFCWTAPI/TestCWTFrequencies.cs
@@ -22,8 +22,11 @@ namespace TestFCWTAPI
                 0.450e6,
                 0.475e6
             };
+            
+            int testNbVoices = testFrequencies.Length;
+            float testC0 = 1.33F;
             double calibrationCoefficient = 7.5e12; 
-            var cwtFrequencies = new CWTFrequencies(testFrequencies);
+            var cwtFrequencies = new CWTFrequencies(testFrequencies, testNbVoices, testC0);
             var badCwtFrequencies = new CWTFrequencies();
 
             Assert.Throws<NullReferenceException>(delegate { 
@@ -32,6 +35,32 @@ namespace TestFCWTAPI
             double trueValue = calibrationCoefficient / Math.Pow(testFrequencies[0], 2);
             double[] mzVals = cwtFrequencies.ToMZValues(calibrationCoefficient);
             Assert.AreEqual(trueValue, mzVals[0]); 
+        }
+        [Test]
+        public void TestCalculateIndicesForFrequencyRange()
+        {
+            double[] testValues = new double[1000];
+            double constant = 1D / 1000D * 2D * Math.PI;
+            for (int i = 0; i < 1000; i++)
+            {
+                double val = (double)i * constant;
+                testValues[i] = val;
+            }
+            double[] cosine = FunctionGenerator.TransformValues(testValues, FunctionGenerator.GenerateCosineWave);
+            CWTObject cosCWT = new(cosine, 1, 6, 200, (float)(2 * Math.PI), 4, false);
+            cosCWT.CalculateFrequencyAxis();
+            var nulledCWTFrequencies = new CWTFrequencies();
+            Assert.Throws<NullReferenceException>(() => nulledCWTFrequencies.CalculateIndicesForFrequencyRange(0.8, 1.4));
+            Assert.Throws<ArgumentException>(() => cosCWT.FrequencyAxis.CalculateIndicesForFrequencyRange(0.01, 2));
+            Assert.Throws<ArgumentException>(() => cosCWT.FrequencyAxis.CalculateIndicesForFrequencyRange(0.09, 28));
+            Assert.Throws<ArgumentException>(() => cosCWT.FrequencyAxis.CalculateIndicesForFrequencyRange(0.09, 0.08));
+            var frequencyIndexRange = cosCWT.FrequencyAxis.CalculateIndicesForFrequencyRange(0.04892, 0.06278);
+            Assert.AreEqual(0, frequencyIndexRange.Item1);
+            Assert.AreEqual(72, frequencyIndexRange.Item2);
+            var endindexRange = cosCWT.FrequencyAxis.CalculateIndicesForFrequencyRange(3.1091, 3.1198);
+            Assert.AreEqual(1198, endindexRange.Item1);
+            Assert.AreEqual(1199, endindexRange.Item2);
+
         }
     }
 }


### PR DESCRIPTION
Put functionality to get frequency axis indices in the CWTFrequencies class. Additionally, fixed the calculation of the frequency axis so that it is in ascending frequency order rather than descending.