### PR TITLE
PlottingUtils_Cleanup

### DIFF
--- a/FCWTAPI/PlottingUtils.cs
+++ b/FCWTAPI/PlottingUtils.cs
@@ -6,54 +6,12 @@ using System.Threading.Tasks;
 using OxyPlot;
 using OxyPlot.Axes;
 using OxyPlot.Series;
+using OxyPlot.SkiaSharp;
 namespace FCWTNET
 {
     public class PlottingUtils
     {
-        /// <summary>
-        /// Creates a heat map plot from a 2D array
-        /// Functionality will be added to scale axes with time and frequency info from CWT
-        /// </summary>
-        /// <param name="data"> Input double[,] to plot</param>
-        /// <param name="plotTitle">String containing the desired plot title</param>
-        /// <returns></returns>
-        public static PlotModel GenerateHeatMap(double[,] data, string plotTitle)
-        {
-            int x0 = 0;
-            int x1 = data.GetLength(0) - 1;
-            int y0 = 0;
-            int y1 = data.GetLength(1) - 1;
-            var model = new PlotModel { Title = plotTitle };
-            model.Axes.Add(new LinearColorAxis { Palette = OxyPalettes.Rainbow(100)});
-            model.Axes.Add(new LinearAxis 
-            { 
-                Position = AxisPosition.Bottom, 
-                Title = "Time (units)",
-                FontSize = 14,
-                TitleFontSize = 16
-                
-            });
-            model.Axes.Add(new LinearAxis 
-            { 
-                Position = AxisPosition.Left, 
-                Title = "f_{0} (units)",
-                FontSize = 14,
-                TitleFontSize = 16,
-                AxisTitleDistance = 10
-            });
-            var hms = new HeatMapSeries
-            {
-                X0 = x0,
-                X1 = x1,
-                Y0 = y0,
-                Y1 = y1,
-                Data = data,
-                RenderMethod = HeatMapRenderMethod.Bitmap
-            };
-            model.Series.Add(hms);
-
-            return model;
-        }
+        
         /// <summary>
         /// Creates a heat map plot from a 2D array with proper frequency and time axes
         /// </summary>
@@ -135,124 +93,17 @@ namespace FCWTNET
 
             return model;
         }
-        /// <summary>
-        /// Method to generate XY plots of individual, composite, or single rows of a 2D array
-        /// Functionality to incorporate time and frequency information later will be added
-        /// </summary>
-        /// <param name="data"></param>
-        /// <param name="rowIndices">int[] of rows to plot</param>
-        /// <param name="plotTitle"></param>
-        /// the "rowIndices" parameter will likely change later to allow time point selection
-        /// <param name="mode">Set the operation mode from the XYPlotOptions Enumerable</param>
-        /// Composite averages a set of rows to create a single composite plot
-        /// Evolution plots all selected rows in the same overlaid plot
-        /// Single plots a single row
-        /// <returns></returns>
-        /// <exception cref="ArgumentNullException"></exception>
-        public static PlotModel GenerateXYPlot(double[,] data, int[] rowIndices, PlotTitles plotTitle, XYPlotOptions mode, string? customTitle = null)
+        
+        public static PlotModel GenerateXYPlotCWT(double[,] data, int[] rowIndices, double[] timeAxis, double[] freqAxis, PlotTitles plotTitle, XYPlotOptions mode, string? customTitle = null)
         {
             string actualTitle;
-            if (plotTitle == PlotTitles.Custom)
+            if (timeAxis.Length != data.GetLength(0))
             {
-                if (customTitle == null)
-                {
-                    throw new ArgumentNullException("customTitle", "If a custom plotTitle is used, a custom title must be entered");
-                }
-                else
-                {
-                    actualTitle = customTitle;
-                }
-
+                throw new ArgumentException("timeAxis must have the same number of timepoints as the CWT", nameof(timeAxis));
             }
-            else { actualTitle = plotTitle.ToString() + " Plot"; }
-            var plotModel = new PlotModel { Title = actualTitle };
-            plotModel.Axes.Add(new LinearAxis 
+            if (freqAxis.Length != data.GetLength(1))
             {
-                Position = AxisPosition.Bottom,
-                MinimumPadding = 0.05, 
-                MaximumPadding = 0.05,
-                Title = "Time (units)",
-                FontSize = 14,
-                TitleFontSize = 16,
-                AxisTitleDistance = 10
-            });
-            plotModel.Axes.Add(new LinearAxis 
-            { 
-                Position = AxisPosition.Left, 
-                MinimumPadding = 0.05, 
-                MaximumPadding = 0.05,
-                Title = "Intensity",
-                FontSize = 14,
-                TitleFontSize = 16,
-                AxisTitleDistance = 10
-            });
-            if(mode == XYPlotOptions.Composite)
-            {
-                var compSeries = new LineSeries();
-                
-                for (int x = 0; x < data.GetLength(0); x++)
-                {
-                    double compValue = 0;
-                    for(int i = 0; i < rowIndices.Length; i++ )
-                        {
-                            compValue += data[rowIndices[i], x];
-                        }
-                    compSeries.Points.Add(new DataPoint(x, compValue));
-                }
-                compSeries.Title = "Composite from f_{0} = " + rowIndices[0].ToString() + " to f_{0} = " + rowIndices[^1].ToString();
-                compSeries.Color = OxyColors.Black;
-                plotModel.Series.Add(compSeries);
-                var legend = new OxyPlot.Legends.Legend
-                {
-                    LegendPlacement = OxyPlot.Legends.LegendPlacement.Outside,
-                    LegendPosition = OxyPlot.Legends.LegendPosition.TopRight,
-                    LegendFontSize = 14
-                };
-                plotModel.Legends.Add(legend);
-
-                return plotModel;
-            }
-            else
-            {
-                LineSeries[] lineSeriesArray = new LineSeries[rowIndices.Length];
-                for (int i = 0; i < rowIndices.Length; i++)
-                {
-                    var individualFrequencySeries = new LineSeries();
-                    for (int x = 0; x < data.GetLength(0); x++)
-                    {
-                        individualFrequencySeries.Points.Add(new DataPoint(x, data[x, rowIndices[i]]));
-                    }
-                    individualFrequencySeries.Title = "f_{0} = " + rowIndices[i].ToString();
-                    lineSeriesArray[i] = individualFrequencySeries;
-                }
-                for (int i = 0; i < lineSeriesArray.Length; i++)
-                {
-                    plotModel.Series.Add(lineSeriesArray[i]);
-                }
-                var legend = new OxyPlot.Legends.Legend
-                {
-                    LegendPlacement = OxyPlot.Legends.LegendPlacement.Outside,
-                    LegendPosition = OxyPlot.Legends.LegendPosition.RightMiddle,
-                    LegendFontSize = 14,
-                };
-                plotModel.Legends.Add(legend);
-                if(mode == XYPlotOptions.Evolution)
-                {
-                    plotModel.DefaultColors = OxyPalettes.Rainbow(plotModel.Series.Count).Colors;
-                }
-                return plotModel;
-            }
-        }
-        public static PlotModel GenerateXYPlotCWT(double[,] data, int[] rowIndices, double[] timeArray, double[] freqArray, PlotTitles plotTitle, XYPlotOptions mode, string? customTitle = null)
-        {
-            string actualTitle;
-            if (timeArray.Length != data.GetLength(0))
-            {
-                throw new ArgumentException("timeArray must have the same number of timepoints as the CWT", nameof(timeArray));
-            }
-            if (freqArray.Length != data.GetLength(1))
-            {
-                throw new ArgumentException("freqArray must have the same number of timepoints as the CWT", nameof(freqArray));
+                throw new ArgumentException("freqAxis must have the same number of timepoints as the CWT", nameof(freqAxis));
             }
             if (plotTitle == PlotTitles.Custom)
             {
@@ -277,8 +128,8 @@ namespace FCWTNET
                 FontSize = 14,
                 TitleFontSize = 16,
                 AxisTitleDistance = 10,
-                Minimum = timeArray[0],
-                Maximum = timeArray[^1],
+                Minimum = timeAxis[0],
+                Maximum = timeAxis[^1],
             });
             plotModel.Axes.Add(new LinearAxis
             {
@@ -301,9 +152,9 @@ namespace FCWTNET
                     {
                         compValue += data[x, rowIndices[i]];
                     }
-                    compSeries.Points.Add(new DataPoint(timeArray[x], compValue));
+                    compSeries.Points.Add(new DataPoint(timeAxis[x], compValue));
                 }
-                compSeries.Title = "Composite from f_{0} = " + freqArray[rowIndices[0]].ToString("G3") + " to f_{0} = " + freqArray[rowIndices[rowIndices.Length - 1]].ToString("G3") + " Hz";
+                compSeries.Title = "Composite from f_{0} = " + freqAxis[rowIndices[0]].ToString("G3") + " to f_{0} = " + freqAxis[rowIndices[rowIndices.Length - 1]].ToString("G3") + " Hz";
                 plotModel.Series.Add(compSeries);
                 compSeries.Color = OxyColors.Black;
                 var legend = new OxyPlot.Legends.Legend
@@ -327,9 +178,9 @@ namespace FCWTNET
                     var indivSer = new LineSeries();
                     for (int x = 0; x < data.GetLength(0); x++)
                     {
-                        indivSer.Points.Add(new DataPoint(timeArray[x], data[x, rowIndices[i]]));
+                        indivSer.Points.Add(new DataPoint(timeAxis[x], data[x, rowIndices[i]]));
                     }
-                    indivSer.Title = "f_{0} = " + freqArray[rowIndices[i]].ToString("G3") + " Hz";
+                    indivSer.Title = "f_{0} = " + freqAxis[rowIndices[i]].ToString("G3") + " Hz";
                     lineSeriesArray[i] = indivSer;
                 }
                 for (int i = 0; i < lineSeriesArray.Length; i++)
@@ -348,6 +199,7 @@ namespace FCWTNET
         }
         /// <summary>
         /// Exports generated plots to PDF files
+        /// Expansion to this method should include options for other file formats
         /// </summary>
         /// <param name="plotModel">Plot to export</param>
         /// <param name="filePath">File path to export the plot to, must contain .pdf extension</param>
@@ -356,13 +208,13 @@ namespace FCWTNET
         /// <exception cref="ArgumentException"></exception>
         public static void ExportPlotPDF(PlotModel plotModel, string filePath, int plotWidth = 700, int plotHeight = 600)
         {
-            if (Path.GetExtension(filePath) != ".pdf")
-                {
-                throw new ArgumentException("fileName must end in .pdf", nameof(filePath));
-                }
+            if (Path.GetExtension(filePath) == null)
+            {
+                filePath = filePath + ".pdf";
+            }
             using (var exportStream = File.Create(filePath))
             {
-                var pdfExport = new PdfExporter
+                var pdfExport = new OxyPlot.SkiaSharp.PdfExporter
                 {
                     Width = plotWidth,
                     Height = plotHeight

--- a/FCWTAPI/PlottingUtils.cs
+++ b/FCWTAPI/PlottingUtils.cs
@@ -56,6 +56,12 @@ namespace FCWTNET
 
             return model;
         }
+        public static PlotModel GenerateCWTHeatMap(double[,] data, string plotTitle)
+        {
+            double[] defaultTimeAxis = new double[data.GetLength(1)];
+            double[] defaultFrequencyAxis = new double[data.GetLength(0)];
+            return GenerateCWTHeatMap(data, plotTitle, defaultTimeAxis, defaultFrequencyAxis);
+        }
         /// <summary>
         /// Creates a contour plot from a 2D array with proper frequency and time axis
         /// </summary>
@@ -93,7 +99,13 @@ namespace FCWTNET
 
             return model;
         }
-        
+        public static PlotModel GenerateCWTContourPlot(double[,] data, string plotTitle)
+        {
+            double[] defaultTimeAxis = new double[data.GetLength(1)];
+            double[] defaultFrequencyAxis = new double[data.GetLength(0)];
+            return GenerateCWTContourPlot(data, plotTitle, defaultTimeAxis, defaultFrequencyAxis);
+        }
+
         public static PlotModel GenerateXYPlotCWT(double[,] data, int[] rowIndices, double[] timeAxis, double[] freqAxis, PlotTitles plotTitle, XYPlotOptions mode, string? customTitle = null)
         {
             string actualTitle;
@@ -196,6 +208,12 @@ namespace FCWTNET
                 plotModel.Legends.Add(legend);
                 return plotModel;
             }
+        }
+        public static PlotModel GenerateXYPlotCWT(double[,] data, int[] rowIndices, PlotTitles plotTitle, XYPlotOptions mode, string? customTitle = null)
+        {
+            double[] defaultTimeAxis = new double[data.GetLength(1)];
+            double[] defaultFrequencyAxis = new double[data.GetLength(0)];
+            return GenerateXYPlotCWT(data, rowIndices, defaultTimeAxis, defaultFrequencyAxis, plotTitle, mode);
         }
         /// <summary>
         /// Exports generated plots to PDF files

--- a/FCWTAPI/fCWT.NET.csproj
+++ b/FCWTAPI/fCWT.NET.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="OxyPlot.Core" Version="2.1.0" />
+    <PackageReference Include="OxyPlot.SkiaSharp" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TestFCWTAPI/PlotingTests.cs
+++ b/TestFCWTAPI/PlotingTests.cs
@@ -3,6 +3,8 @@ using System;
 using FCWTNET;
 using System.Linq;
 using OxyPlot;
+using OxyPlot.Axes;
+using OxyPlot.Series;
 using System.IO;
 using System.Text;
 
@@ -20,37 +22,40 @@ namespace TestFCWTAPI
         public void TestExportPlotPDF()
         {
             double[,] testData = TestDataGeneration.GenerateGaussian();
-            var testPlot = PlottingUtils.GenerateHeatMap(testData, "Test Heatmap");
-            Assert.Throws<ArgumentException>(() => PlottingUtils.ExportPlotPDF(testPlot, "testplot"));
-            PlottingUtils.ExportPlotPDF(testPlot, "testplot.pdf");
-        }
-        [Test]
-        public void TestGenerateHeatMap()
-        {
-            double[,] testData = TestDataGeneration.GenerateGaussian();
-            var testHeatMap = PlottingUtils.GenerateHeatMap(testData, "Test Heatmap");
-            PlottingUtils.ExportPlotPDF(testHeatMap, "testheatmap.pdf");
-        }
-        [Test]
-        public void TestGenerateXYPlot()
-        {
-            double[,] testData = TestDataGeneration.GenerateGaussian();
-            int[] testMultiple = new int[] { 300, 400, 450, 500, 530, 620, 680 };
-            int[] testSingle = new int[] { 500 };
-            var testCompositePlot = PlottingUtils.GenerateXYPlot(testData, testMultiple, PlottingUtils.PlotTitles.Composite, PlottingUtils.XYPlotOptions.Composite);
-            var testEvolutionPlot = PlottingUtils.GenerateXYPlot(testData, testMultiple, PlottingUtils.PlotTitles.Evolution, PlottingUtils.XYPlotOptions.Evolution);
-            var testSinglePlot = PlottingUtils.GenerateXYPlot(testData, testSingle, PlottingUtils.PlotTitles.Single, PlottingUtils.XYPlotOptions.Evolution);
-            var testCustomTitle = PlottingUtils.GenerateXYPlot(testData, testSingle, PlottingUtils.PlotTitles.Custom, PlottingUtils.XYPlotOptions.Single, "Custom Title");
-            Assert.Throws<ArgumentNullException>(() => PlottingUtils.GenerateXYPlot(testData, testSingle, PlottingUtils.PlotTitles.Custom, PlottingUtils.XYPlotOptions.Single));
-            PlottingUtils.ExportPlotPDF(testCompositePlot, "testcomposite.pdf");
-            PlottingUtils.ExportPlotPDF(testEvolutionPlot, "testevolution.pdf");
-            PlottingUtils.ExportPlotPDF(testSinglePlot, "testsingle.pdf");
-            PlottingUtils.ExportPlotPDF(testCustomTitle, "customtitle.pdf");
+            double[] xAxis = new double[1000];
+            double[] yAxis = new double[1000];
+            for (int i = 0; i < testData.GetLength(0); i++)
+            {
+                xAxis[i] = (double)i;
+                yAxis[i] = (double)i *3.4;
+            }
+            var plotModel = new PlotModel { Title = "Test Plot" };
+            plotModel.Axes.Add(new LinearAxis
+            {
+                Position = AxisPosition.Bottom,
+                Title = "X-Axis",
+                Minimum = xAxis[0],
+                Maximum = xAxis[^1],
+            });
+            plotModel.Axes.Add(new LinearAxis
+            {
+                Position = AxisPosition.Left,
+                Title = "Y-Axis",
+                Minimum = yAxis[0],
+                Maximum = yAxis[^1],
+            });
+            var testSeries = new LineSeries();
+            for (int i = 0; i < xAxis.Length; i++)
+            {
+                testSeries.Points.Add(new DataPoint(xAxis[i], yAxis[i]));
+            }
+            plotModel.Series.Add(testSeries);
+            PlottingUtils.ExportPlotPDF(plotModel, "testExport.pdf");
         }
         [Test]
         public void TestGenerateCWTHeatMap()
         {
-            double[,] testData = TestDataGeneration.GenerateAssymetricalGaussian();
+            double[,] testData = TestDataGeneration.GenerateAsymmetricalGaussian();
             double[] timeAxis = new double[1000];
             double[] freqAxis = new double[1000];
             for (int i = 0; i < testData.GetLength(0); i++)
@@ -64,7 +69,7 @@ namespace TestFCWTAPI
         [Test]
         public void TestGenerateCWTContourPlot()
         {
-            double[,] testData = TestDataGeneration.GenerateAssymetricalGaussian();
+            double[,] testData = TestDataGeneration.GenerateAsymmetricalGaussian();
             double[] timeAxis = new double[1000];
             double[] freqAxis = new double[1000];
             for (int i = 0; i < testData.GetLength(0); i++)
@@ -78,7 +83,7 @@ namespace TestFCWTAPI
         [Test]
         public void TestGenerateXYPlotCWT()
         {
-            double[,] testData = TestDataGeneration.GenerateAssymetricalGaussian();
+            double[,] testData = TestDataGeneration.GenerateAsymmetricalGaussian();
             int[] testMultiple = new int[] { 300, 400, 450, 500, 530, 620, 680 };
             int[] testSingle = new int[] { 500 };
             double[] timeAxis = new double[1000];


### PR DESCRIPTION
Removed Generate(typeofplot) methods and replaced them with overloads of the GenerateCWT(typeofplot) methods. Additionally, changed exception handling for ExportPlotPDF to add the .pdf extension if it is absent rather than throwing an error. Unit test for ExportPlotPDF was also fixed to test the module independently of the other plotting functions.