### PR TITLE
Added M/Z values and true frequencies to the CWTFrequencies object

### DIFF
--- a/FCWTAPI/CWTFrequencies.cs
+++ b/FCWTAPI/CWTFrequencies.cs
@@ -100,6 +100,7 @@ namespace FCWTNET
         /// <summary>
         /// Method to get starting and ending indices for a particular frequency range.
         /// This is intentionally greedy in the sense that the index range will always include the desired start and end frequencies
+        /// This method can only be used when working with wavelet frequencies 
         /// </summary>
         /// <param name="startFrequency">Desired starting frequency</param>
         /// <param name="endFrequency">Desired ending frequency</param>
@@ -166,6 +167,10 @@ namespace FCWTNET
                     endFrequency = TrueFreqToWaveletFreq(endValue);
                     break;
                 case FrequencyUnits.MZValues:
+                    if (startValue <= endValue)
+                    {
+                        throw new ArgumentException("startValue must be > endValue when using m/z values", nameof(startValue));
+                    }
                     startFrequency = MZValueToWaveletFreq(startValue);
                     endFrequency = MZValueToWaveletFreq(endValue);
                     break;

--- a/FCWTAPI/CWTObject.cs
+++ b/FCWTAPI/CWTObject.cs
@@ -26,14 +26,15 @@ namespace FCWTNET
         public int Nthreads { get; }
         public bool Use_Optimization_Schemes { get; }
         public int? SamplingRate { get; }
-        public double? CalibrationCoefficient { get; }
+        public double? CalibrationCoefficient { get; private set; }
 
         public CWTOutput? OutputCWT { get; private set; }
         public CWTFrequencies? FrequencyAxis { get; private set; }
         public double[]? TimeAxis { get; private set; }
         public string? WorkingPath { get; }
 
-        public CWTObject(double[] inputData, int psoctave, int pendoctave, int pnbvoice, float c0, int nthreads, bool use_optimization_schemes, int? samplingRate = null, string? workingPath = null)
+        public CWTObject(double[] inputData, int psoctave, int pendoctave, int pnbvoice, float c0, int nthreads, bool use_optimization_schemes, 
+            int? samplingRate = null, double? calibrationCoefficient = null, string? workingPath = null)
         {
             InputData = inputData;
             Psoctave = psoctave;
@@ -43,6 +44,7 @@ namespace FCWTNET
             Nthreads = nthreads;
             Use_Optimization_Schemes = use_optimization_schemes;
             SamplingRate = samplingRate;
+            CalibrationCoefficient = calibrationCoefficient;
             OutputCWT = null;
             FrequencyAxis = null;
             TimeAxis = null;

--- a/FCWTAPI/CWTObject.cs
+++ b/FCWTAPI/CWTObject.cs
@@ -26,6 +26,7 @@ namespace FCWTNET
         public int Nthreads { get; }
         public bool Use_Optimization_Schemes { get; }
         public int? SamplingRate { get; }
+        public double? CalibrationCoefficient { get; }
 
         public CWTOutput? OutputCWT { get; private set; }
         public CWTFrequencies? FrequencyAxis { get; private set; }
@@ -84,7 +85,7 @@ namespace FCWTNET
             {
                 freqArray[^i] = C0 / Math.Pow(2, (1 + (i) * deltaA));
             }
-            FrequencyAxis = new CWTFrequencies(freqArray, Pnbvoice, C0);            
+            FrequencyAxis = new CWTFrequencies(freqArray, Pnbvoice, SamplingRate, CalibrationCoefficient);            
         }
         /// <summary>
         /// Generates an array corresponding to the individual timepoints of the transient operated on by the CWT
@@ -133,7 +134,8 @@ namespace FCWTNET
         /// <param name="dataName">Optional name of the data to pass into the title of the plot</param>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
-        public void GenerateHeatMap(CWTFeatures cwtFeature, string fileName, string? dataName = null)
+        public void GenerateHeatMap(CWTFeatures cwtFeature, string fileName, CWTFrequencies.FrequencyUnits 
+            frequencyAxisUnits, string? dataName = null)
         {
             if (TimeAxis == null)
             {
@@ -151,6 +153,27 @@ namespace FCWTNET
             if (Path.GetExtension(fileName) != ".pdf")
             {
                 throw new ArgumentException(nameof(fileName), "fileName must have the .pdf extension");
+            }
+            double[] plotFrequencyAxis;
+            switch (frequencyAxisUnits)
+            {
+                case CWTFrequencies.FrequencyUnits.TrueFrequency:
+                    if (FrequencyAxis.TrueFrequencies.Equals(null))
+                    {
+                        throw new NullReferenceException("Error FrequencyAxis.TrueFrequencies is null");
+                    }
+                    plotFrequencyAxis = FrequencyAxis.TrueFrequencies;
+                    break;
+                case CWTFrequencies.FrequencyUnits.MZValues:
+                    if (FrequencyAxis.MZValues.Equals(null))
+                    {
+                        throw new NullReferenceException("Error FrequencyAxis.MZValues is null");
+                    }
+                    plotFrequencyAxis = FrequencyAxis.MZValues;
+                    break;
+                default:
+                    plotFrequencyAxis = FrequencyAxis.WaveletCenterFrequencies;
+                    break;
             }
             double[,] data;
             if (cwtFeature == CWTFeatures.Imaginary)
@@ -190,8 +213,8 @@ namespace FCWTNET
                 {
                     xyReflectedData[j, i] = data[i, j];
                 }
-            }
-            PlotModel cwtPlot = PlottingUtils.GenerateCWTHeatMap(xyReflectedData, title, TimeAxis, FrequencyAxis.WaveletCenterFrequencies);
+            }            
+            PlotModel cwtPlot = PlottingUtils.GenerateCWTHeatMap(xyReflectedData, title, TimeAxis, plotFrequencyAxis);
             string filePath = Path.Combine(WorkingPath, fileName);
             PlottingUtils.ExportPlotPDF(cwtPlot, filePath);
         }
@@ -203,13 +226,14 @@ namespace FCWTNET
         /// <param name="cwtFeature">Feature of the CWT to be plotted</param>
         /// <param name="fileName">File to write the plot to</param>
         /// <param name="plotMode">Specifies the type of plot to generate</param>
-        /// <param name="startFrequency">Starting frequency to sample for the plot</param>
-        /// <param name="endFrequency">End frequency to sample for the plot</param>
+        /// <param name="startValue">Starting frequency to sample for the plot</param>
+        /// <param name="endValue">End frequency to sample for the plot</param>
         /// <param name="sampleNumber">Number of frequencies to sample</param>
         /// <param name="dataName">Name of the data to enter</param>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentException"></exception>
-        public void GenerateXYPlot(CWTFeatures cwtFeature, string fileName, PlottingUtils.XYPlotOptions plotMode, double startFrequency, double? endFrequency = null, int? sampleNumber = null, string? dataName = null)
+        public void GenerateXYPlot(CWTFeatures cwtFeature, string fileName, PlottingUtils.XYPlotOptions plotMode, CWTFrequencies.FrequencyUnits frequencyAxisUnits,
+            double startValue, double ? endValue = null, int? sampleNumber = null, string? dataName = null)
         {
             if (TimeAxis == null)
             {
@@ -227,6 +251,31 @@ namespace FCWTNET
             if (Path.GetExtension(fileName) != ".pdf")
             {
                 throw new ArgumentException(nameof(fileName), "fileName must have the .pdf extension");
+            }
+            double[] plotFrequencyAxis;
+            switch (frequencyAxisUnits)
+            {
+                case CWTFrequencies.FrequencyUnits.TrueFrequency:
+                    if (FrequencyAxis.TrueFrequencies.Equals(null))
+                    {
+                        throw new NullReferenceException("Error FrequencyAxis.TrueFrequencies is null");
+                    }
+                    plotFrequencyAxis = FrequencyAxis.TrueFrequencies;
+                    break;
+                case CWTFrequencies.FrequencyUnits.MZValues:
+                    if (FrequencyAxis.MZValues.Equals(null))
+                    {
+                        throw new NullReferenceException("Error FrequencyAxis.MZValues is null");
+                    }
+                    plotFrequencyAxis = FrequencyAxis.MZValues;
+                    break;
+                default:
+                    if (FrequencyAxis.WaveletCenterFrequencies.Equals(null))
+                    {
+                        throw new NullReferenceException("Error FrequencyAxis.WaveletCenterFrequencies is null");
+                    }
+                    plotFrequencyAxis = FrequencyAxis.WaveletCenterFrequencies;
+                    break;
             }
             double[,] data;
             if (cwtFeature == CWTFeatures.Imaginary)
@@ -263,9 +312,9 @@ namespace FCWTNET
             if (plotMode == PlottingUtils.XYPlotOptions.Evolution || plotMode == PlottingUtils.XYPlotOptions.Composite)
             {
 
-                if(endFrequency != null && sampleNumber != null)
+                if(endValue != null && sampleNumber != null)
                 {
-                    (int, int) freqIndices = FrequencyAxis.CalculateIndicesForFrequencyRange((double)startFrequency, (double)endFrequency);
+                    (int, int) freqIndices = FrequencyAxis.CalculateIndicesForFrequencyRange((double)startValue, (double)endValue, frequencyAxisUnits);
                     int maxFrequencies = freqIndices.Item2 - freqIndices.Item1;                    
                     if (sampleNumber < (maxFrequencies))
                     {
@@ -302,7 +351,20 @@ namespace FCWTNET
             }
             else
             {
-                int rawFrequencyIndex = Array.BinarySearch(FrequencyAxis.WaveletCenterFrequencies, startFrequency);
+                double singleFrequency;
+                switch (frequencyAxisUnits)
+                {
+                    case CWTFrequencies.FrequencyUnits.TrueFrequency:
+                        singleFrequency = FrequencyAxis.TrueFreqToWaveletFreq(startValue);
+                        break;
+                    case CWTFrequencies.FrequencyUnits.MZValues:
+                        singleFrequency = FrequencyAxis.MZValueToWaveletFreq(startValue);
+                        break;
+                    default:
+                        singleFrequency = startValue;
+                        break;
+                }
+                int rawFrequencyIndex = Array.BinarySearch(FrequencyAxis.WaveletCenterFrequencies, singleFrequency);
                 int frequencyIndex = rawFrequencyIndex < 0 ? -rawFrequencyIndex + 1 : rawFrequencyIndex;
                 indFrequencies = new int[] {frequencyIndex};
             }
@@ -314,7 +376,7 @@ namespace FCWTNET
                     xyReflectedData[j, i] = data[i, j];
                 }
             }
-            PlotModel cwtPlot = PlottingUtils.GenerateXYPlotCWT(xyReflectedData, indFrequencies, TimeAxis, FrequencyAxis.WaveletCenterFrequencies, PlottingUtils.PlotTitles.Custom, plotMode, title);
+            PlotModel cwtPlot = PlottingUtils.GenerateXYPlotCWT(xyReflectedData, indFrequencies, TimeAxis, plotFrequencyAxis, PlottingUtils.PlotTitles.Custom, plotMode, title);
 
             string filePath = Path.Combine(WorkingPath, fileName);
             PlottingUtils.ExportPlotPDF(cwtPlot, filePath);

--- a/TestFCWTAPI/CWTObjectTests.cs
+++ b/TestFCWTAPI/CWTObjectTests.cs
@@ -75,14 +75,14 @@ namespace TestFCWTAPI
             string testWorkingPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestDataFiles");
             CWTObject cosCWT = new(cosine, 1, 6, 200, 50, 4, false, 1000, workingPath: testWorkingPath);
             string testDataName = "TestCos";
-            Assert.Throws<ArgumentNullException>(() => cosCWT.GenerateHeatMap(CWTObject.CWTFeatures.Modulus, "xyReflectedHeatmapc0-0.001.pdf", testDataName));
+            Assert.Throws<ArgumentNullException>(() => cosCWT.GenerateHeatMap(CWTObject.CWTFeatures.Modulus, "xyReflectedHeatmapc0-0.001.pdf", CWTFrequencies.FrequencyUnits.WaveletFrequency, testDataName));
             cosCWT.PerformCWT();
-            Assert.Throws<ArgumentNullException>(() => cosCWT.GenerateHeatMap(CWTObject.CWTFeatures.Modulus, "xyReflectedHeatmapc0-0.001.pdf", testDataName));
+            Assert.Throws<ArgumentNullException>(() => cosCWT.GenerateHeatMap(CWTObject.CWTFeatures.Modulus, "xyReflectedHeatmapc0-0.001.pdf", CWTFrequencies.FrequencyUnits.WaveletFrequency, testDataName));
             cosCWT.CalculateTimeAxis();
-            Assert.Throws<ArgumentNullException>(() => cosCWT.GenerateHeatMap(CWTObject.CWTFeatures.Modulus, "xyReflectedHeatmapc0-0.001.pdf", testDataName));
+            Assert.Throws<ArgumentNullException>(() => cosCWT.GenerateHeatMap(CWTObject.CWTFeatures.Modulus, "xyReflectedHeatmapc0-0.001.pdf", CWTFrequencies.FrequencyUnits.WaveletFrequency, testDataName));
             cosCWT.CalculateFrequencyAxis();
-            cosCWT.GenerateHeatMap(CWTObject.CWTFeatures.Modulus, "cosTestCWTHeatmap.pdf", testDataName);
-            Assert.Throws<ArgumentException>(() => cosCWT.GenerateHeatMap(CWTObject.CWTFeatures.Modulus, "xyReflectedHeatmapc0-0.001.xlsx", testDataName));
+            cosCWT.GenerateHeatMap(CWTObject.CWTFeatures.Modulus, "cosTestCWTHeatmap.pdf", CWTFrequencies.FrequencyUnits.WaveletFrequency, testDataName);
+            Assert.Throws<ArgumentException>(() => cosCWT.GenerateHeatMap(CWTObject.CWTFeatures.Modulus, "xyReflectedHeatmapc0-0.001.xlsx", CWTFrequencies.FrequencyUnits.WaveletFrequency, testDataName));
 
 
         }
@@ -95,20 +95,28 @@ namespace TestFCWTAPI
             string testWorkingPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestDataFiles");
             CWTObject cosCWT = new(cosine, 1, 6, 200, 50, 4, false, 1000, workingPath: testWorkingPath);
             string testDataName = "TestCos";
-            Assert.Throws<ArgumentNullException>(() => cosCWT.GenerateXYPlot(CWTObject.CWTFeatures.Modulus, "testcosCWTEvolution.pdf", PlottingUtils.XYPlotOptions.Evolution, 1.8, 2.4, 10, testDataName));
+            Assert.Throws<ArgumentNullException>(() => cosCWT.GenerateXYPlot(CWTObject.CWTFeatures.Modulus, "testcosCWTEvolution.pdf", PlottingUtils.XYPlotOptions.Evolution, 
+                CWTFrequencies.FrequencyUnits.WaveletFrequency, 1.8, 2.4, 10, testDataName));
             cosCWT.PerformCWT();
-            Assert.Throws<ArgumentNullException>(() => cosCWT.GenerateXYPlot(CWTObject.CWTFeatures.Modulus, "testcosCWTEvolution.pdf", PlottingUtils.XYPlotOptions.Evolution, 1.8, 2.4, 10, testDataName));
+            Assert.Throws<ArgumentNullException>(() => cosCWT.GenerateXYPlot(CWTObject.CWTFeatures.Modulus, "testcosCWTEvolution.pdf", PlottingUtils.XYPlotOptions.Evolution, 
+                CWTFrequencies.FrequencyUnits.WaveletFrequency, 1.8, 2.4, 10, testDataName));
             cosCWT.CalculateTimeAxis();
-            Assert.Throws<ArgumentNullException>(() => cosCWT.GenerateXYPlot(CWTObject.CWTFeatures.Modulus, "testcosCWTEvolution.pdf", PlottingUtils.XYPlotOptions.Evolution, 1.8, 2.4, 10, testDataName));
+            Assert.Throws<ArgumentNullException>(() => cosCWT.GenerateXYPlot(CWTObject.CWTFeatures.Modulus, "testcosCWTEvolution.pdf", PlottingUtils.XYPlotOptions.Evolution, 
+                CWTFrequencies.FrequencyUnits.WaveletFrequency, 1.8, 2.4, 10, testDataName));
             cosCWT.CalculateFrequencyAxis();            
-            cosCWT.GenerateXYPlot(CWTObject.CWTFeatures.Modulus, "testcosCWTEvolution.pdf", PlottingUtils.XYPlotOptions.Evolution, 1.8, 2.4, 10, testDataName);
+            cosCWT.GenerateXYPlot(CWTObject.CWTFeatures.Modulus, "testcosCWTEvolution.pdf", PlottingUtils.XYPlotOptions.Evolution, 
+                CWTFrequencies.FrequencyUnits.WaveletFrequency, 1.8, 2.4, 10, testDataName);
             // Tests composite summing a limited number of steps
-            cosCWT.GenerateXYPlot(CWTObject.CWTFeatures.Modulus, "testcosCWTComposite_10Steps.pdf", PlottingUtils.XYPlotOptions.Composite, 1.8, 2.4, 10, testDataName);
+            cosCWT.GenerateXYPlot(CWTObject.CWTFeatures.Modulus, "testcosCWTComposite_10Steps.pdf", PlottingUtils.XYPlotOptions.Composite, 
+                CWTFrequencies.FrequencyUnits.WaveletFrequency, 1.8, 2.4, 10, testDataName);
             // Test composite summing all steps in the range
-            cosCWT.GenerateXYPlot(CWTObject.CWTFeatures.Modulus, "testcosCWTComposite_AllSteps.pdf", PlottingUtils.XYPlotOptions.Composite, 1.8, 2.4, 100000000, testDataName);
-            cosCWT.GenerateXYPlot(CWTObject.CWTFeatures.Modulus, "testcosCWTSingle.pdf", PlottingUtils.XYPlotOptions.Single, 1.97);
-            Assert.Throws<ArgumentNullException>(() => cosCWT.GenerateXYPlot(CWTObject.CWTFeatures.Modulus, "testcosCWTEvolution.pdf", PlottingUtils.XYPlotOptions.Evolution, 2));
-            Assert.Throws<ArgumentException>(() => cosCWT.GenerateXYPlot(CWTObject.CWTFeatures.Modulus, "testcosCWTEvolution.xlsx", PlottingUtils.XYPlotOptions.Evolution, 1.8, 2.4, 10, testDataName));
+            cosCWT.GenerateXYPlot(CWTObject.CWTFeatures.Modulus, "testcosCWTComposite_AllSteps.pdf", PlottingUtils.XYPlotOptions.Composite, 
+                CWTFrequencies.FrequencyUnits.WaveletFrequency, 1.8, 2.4, 100000000, testDataName);
+            cosCWT.GenerateXYPlot(CWTObject.CWTFeatures.Modulus, "testcosCWTSingle.pdf",  PlottingUtils.XYPlotOptions.Single, CWTFrequencies.FrequencyUnits.WaveletFrequency, 1.97);
+            Assert.Throws<ArgumentNullException>(() => cosCWT.GenerateXYPlot(CWTObject.CWTFeatures.Modulus, "testcosCWTEvolution.pdf", PlottingUtils.XYPlotOptions.Evolution, 
+                CWTFrequencies.FrequencyUnits.WaveletFrequency, 2));
+            Assert.Throws<ArgumentException>(() => cosCWT.GenerateXYPlot(CWTObject.CWTFeatures.Modulus, "testcosCWTEvolution.xlsx", PlottingUtils.XYPlotOptions.Evolution, 
+                CWTFrequencies.FrequencyUnits.WaveletFrequency, 1.8, 2.4, 10, testDataName));
         }
         [Test]
         public void TestCosine()

--- a/TestFCWTAPI/CWTObjectTests.cs
+++ b/TestFCWTAPI/CWTObjectTests.cs
@@ -73,7 +73,7 @@ namespace TestFCWTAPI
                                         .Select(i => FunctionGenerator.GenerateCosineWave((double)i * 0.08 * Math.PI))
                                         .ToArray();
             string testWorkingPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestDataFiles");
-            CWTObject cosCWT = new(cosine, 1, 6, 200, 50, 4, false, 1000, workingPath: testWorkingPath);
+            CWTObject cosCWT = new(cosine, 1, 6, 200, 50, 4, false, 100000, 7.5e12, workingPath: testWorkingPath);
             string testDataName = "TestCos";
             Assert.Throws<ArgumentNullException>(() => cosCWT.GenerateHeatMap(CWTObject.CWTFeatures.Modulus, "xyReflectedHeatmapc0-0.001.pdf", CWTFrequencies.FrequencyUnits.WaveletFrequency, testDataName));
             cosCWT.PerformCWT();
@@ -81,7 +81,11 @@ namespace TestFCWTAPI
             cosCWT.CalculateTimeAxis();
             Assert.Throws<ArgumentNullException>(() => cosCWT.GenerateHeatMap(CWTObject.CWTFeatures.Modulus, "xyReflectedHeatmapc0-0.001.pdf", CWTFrequencies.FrequencyUnits.WaveletFrequency, testDataName));
             cosCWT.CalculateFrequencyAxis();
+            cosCWT.FrequencyAxis.CalculateTrueFrequencies();
+            cosCWT.FrequencyAxis.CalculateMZValues();
             cosCWT.GenerateHeatMap(CWTObject.CWTFeatures.Modulus, "cosTestCWTHeatmap.pdf", CWTFrequencies.FrequencyUnits.WaveletFrequency, testDataName);
+            cosCWT.GenerateHeatMap(CWTObject.CWTFeatures.Modulus, "cosTestCWTHeatmapTrueFreq.pdf", CWTFrequencies.FrequencyUnits.TrueFrequency, testDataName);
+            cosCWT.GenerateHeatMap(CWTObject.CWTFeatures.Modulus, "cosTestCWTHeatmapMZVals.pdf", CWTFrequencies.FrequencyUnits.MZValues, testDataName);
             Assert.Throws<ArgumentException>(() => cosCWT.GenerateHeatMap(CWTObject.CWTFeatures.Modulus, "xyReflectedHeatmapc0-0.001.xlsx", CWTFrequencies.FrequencyUnits.WaveletFrequency, testDataName));
 
 
@@ -93,7 +97,7 @@ namespace TestFCWTAPI
                                         .Select(i => FunctionGenerator.GenerateCosineWave((double)i * 0.08 * Math.PI))
                                         .ToArray();
             string testWorkingPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestDataFiles");
-            CWTObject cosCWT = new(cosine, 1, 6, 200, 50, 4, false, 1000, workingPath: testWorkingPath);
+            CWTObject cosCWT = new(cosine, 1, 6, 200, 50, 4, false, 100000, 7.5e12, workingPath: testWorkingPath);
             string testDataName = "TestCos";
             Assert.Throws<ArgumentNullException>(() => cosCWT.GenerateXYPlot(CWTObject.CWTFeatures.Modulus, "testcosCWTEvolution.pdf", PlottingUtils.XYPlotOptions.Evolution, 
                 CWTFrequencies.FrequencyUnits.WaveletFrequency, 1.8, 2.4, 10, testDataName));
@@ -103,7 +107,9 @@ namespace TestFCWTAPI
             cosCWT.CalculateTimeAxis();
             Assert.Throws<ArgumentNullException>(() => cosCWT.GenerateXYPlot(CWTObject.CWTFeatures.Modulus, "testcosCWTEvolution.pdf", PlottingUtils.XYPlotOptions.Evolution, 
                 CWTFrequencies.FrequencyUnits.WaveletFrequency, 1.8, 2.4, 10, testDataName));
-            cosCWT.CalculateFrequencyAxis();            
+            cosCWT.CalculateFrequencyAxis();
+            cosCWT.FrequencyAxis.CalculateTrueFrequencies();
+            cosCWT.FrequencyAxis.CalculateMZValues();
             cosCWT.GenerateXYPlot(CWTObject.CWTFeatures.Modulus, "testcosCWTEvolution.pdf", PlottingUtils.XYPlotOptions.Evolution, 
                 CWTFrequencies.FrequencyUnits.WaveletFrequency, 1.8, 2.4, 10, testDataName);
             // Tests composite summing a limited number of steps
@@ -117,6 +123,10 @@ namespace TestFCWTAPI
                 CWTFrequencies.FrequencyUnits.WaveletFrequency, 2));
             Assert.Throws<ArgumentException>(() => cosCWT.GenerateXYPlot(CWTObject.CWTFeatures.Modulus, "testcosCWTEvolution.xlsx", PlottingUtils.XYPlotOptions.Evolution, 
                 CWTFrequencies.FrequencyUnits.WaveletFrequency, 1.8, 2.4, 10, testDataName));
+            cosCWT.GenerateXYPlot(CWTObject.CWTFeatures.Modulus, "testcosCWTEvolutionTrueFreq.pdf", PlottingUtils.XYPlotOptions.Evolution,
+                CWTFrequencies.FrequencyUnits.TrueFrequency, 180000, 240000, 10, testDataName);
+            cosCWT.GenerateXYPlot(CWTObject.CWTFeatures.Modulus, "testcosCWTEvolutionMZVals.pdf", PlottingUtils.XYPlotOptions.Evolution,
+                CWTFrequencies.FrequencyUnits.MZValues, 231.489, 130.208, 10, testDataName);
         }
         [Test]
         public void TestCosine()

--- a/TestFCWTAPI/TestCWTFrequencies.cs
+++ b/TestFCWTAPI/TestCWTFrequencies.cs
@@ -15,7 +15,27 @@ namespace TestFCWTAPI
         }
 
         [Test]
-        public void TestToMzValues()
+        public void TestCalculateTrueFrequencies()
+        {
+            double[] testFrequencies = new double[]
+            {
+                0.450e6,
+                0.475e6
+            };
+            int testNbVoices = testFrequencies.Length;
+            int testSampleRate = 50000;
+            var cwtFrequencies = new CWTFrequencies(testFrequencies, testNbVoices, testSampleRate);
+            var noSampleRate = new CWTFrequencies(testFrequencies, testNbVoices);
+            var badCwtFrequencies = new CWTFrequencies();
+            Assert.Throws<NullReferenceException>(() => badCwtFrequencies.CalculateTrueFrequencies());
+            Assert.Throws<NullReferenceException>(() => noSampleRate.CalculateTrueFrequencies());
+            cwtFrequencies.CalculateTrueFrequencies();
+            double trueValue = testSampleRate * testFrequencies[0];
+            Assert.AreEqual(trueValue, cwtFrequencies.TrueFrequencies[0]);
+            
+        }
+        [Test]
+        public void TestCalculateMzValues()
         {
             double[] testFrequencies = new double[]
             {
@@ -24,17 +44,21 @@ namespace TestFCWTAPI
             };
             
             int testNbVoices = testFrequencies.Length;
-            float testC0 = 1.33F;
+            int testSampleRate = 50000;
             double calibrationCoefficient = 7.5e12; 
-            var cwtFrequencies = new CWTFrequencies(testFrequencies, testNbVoices, testC0);
+            var cwtFrequencies = new CWTFrequencies(testFrequencies, testNbVoices, testSampleRate, calibrationCoefficient);
+            var noCalibration = new CWTFrequencies(testFrequencies, testNbVoices, testSampleRate);
             var badCwtFrequencies = new CWTFrequencies();
-
             Assert.Throws<NullReferenceException>(delegate { 
-                badCwtFrequencies.ToMZValues(calibrationCoefficient);  
+                badCwtFrequencies.CalculateMZValues();  
             });
-            double trueValue = calibrationCoefficient / Math.Pow(testFrequencies[0], 2);
-            double[] mzVals = cwtFrequencies.ToMZValues(calibrationCoefficient);
-            Assert.AreEqual(trueValue, mzVals[0]); 
+            noCalibration.CalculateTrueFrequencies();
+            Assert.Throws<NullReferenceException>(() => noCalibration.CalculateMZValues());
+            double trueValue = calibrationCoefficient / Math.Pow((testFrequencies[0] / testSampleRate), 2);
+            Assert.Throws<NullReferenceException>(() => cwtFrequencies.CalculateMZValues());
+            cwtFrequencies.CalculateTrueFrequencies();
+            cwtFrequencies.CalculateMZValues();
+            Assert.AreEqual(trueValue, cwtFrequencies.MZValues[0]); 
         }
         [Test]
         public void TestCalculateIndicesForFrequencyRange()
@@ -61,6 +85,43 @@ namespace TestFCWTAPI
             Assert.AreEqual(1198, endindexRange.Item1);
             Assert.AreEqual(1199, endindexRange.Item2);
 
+
+        }        
+        [Test]
+        public static void TestTrueFreqToWaveletFreq()
+        {
+            double testTrueFrequency = 5000;
+            double[] testFrequencies = new double[]
+            {
+                0.450e6,
+                0.475e6
+            };
+            int testNbVoices = testFrequencies.Length;
+            int testSampleRate = 50000;
+            double testWaveletFrequency = testTrueFrequency / testSampleRate;
+            var cwtFrequencies = new CWTFrequencies(testFrequencies, testNbVoices, testSampleRate);
+            var noSampleRate = new CWTFrequencies(testFrequencies, testNbVoices);
+            Assert.Throws<NullReferenceException>(() => noSampleRate.TrueFreqToWaveletFreq(testTrueFrequency));
+            Assert.AreEqual(cwtFrequencies.TrueFreqToWaveletFreq(testTrueFrequency), testWaveletFrequency);
+        }
+        [Test]
+        public static void TestMZValueToWaveletFreq()
+        {
+            double testMZValue = 1000;
+            double[] testFrequencies = new double[]
+            {
+                0.450e6,
+                0.475e6
+            };
+            int testNbVoices = testFrequencies.Length;
+            int testSampleRate = 50000;
+            double testCalibrationCoefficient = 7.5e12;
+            double testTrueFrequency = Math.Sqrt(testCalibrationCoefficient / testMZValue);
+            double testWaveletFrequency = testTrueFrequency / testSampleRate;
+            var cwtFrequencies = new CWTFrequencies(testFrequencies, testNbVoices, testSampleRate, testCalibrationCoefficient);
+            var noCalibration = new CWTFrequencies(testFrequencies, testNbVoices, testSampleRate);
+            Assert.Throws<NullReferenceException>(() => noCalibration.MZValueToWaveletFreq(testTrueFrequency));
+            Assert.AreEqual(cwtFrequencies.TrueFreqToWaveletFreq(testTrueFrequency), testWaveletFrequency);
         }
     }
 }

--- a/TestFCWTAPI/TestCWTFrequencies.cs
+++ b/TestFCWTAPI/TestCWTFrequencies.cs
@@ -54,7 +54,7 @@ namespace TestFCWTAPI
             });
             noCalibration.CalculateTrueFrequencies();
             Assert.Throws<NullReferenceException>(() => noCalibration.CalculateMZValues());
-            double trueValue = calibrationCoefficient / Math.Pow((testFrequencies[0] / testSampleRate), 2);
+            double trueValue = calibrationCoefficient / Math.Pow((testFrequencies[0] * testSampleRate), 2);
             Assert.Throws<NullReferenceException>(() => cwtFrequencies.CalculateMZValues());
             cwtFrequencies.CalculateTrueFrequencies();
             cwtFrequencies.CalculateMZValues();
@@ -71,8 +71,10 @@ namespace TestFCWTAPI
                 testValues[i] = val;
             }
             double[] cosine = FunctionGenerator.TransformValues(testValues, FunctionGenerator.GenerateCosineWave);
-            CWTObject cosCWT = new(cosine, 1, 6, 200, (float)(2 * Math.PI), 4, false);
+            CWTObject cosCWT = new(cosine, 1, 6, 200, (float)(2 * Math.PI), 4, false, 100000, 7.5e12);
             cosCWT.CalculateFrequencyAxis();
+            cosCWT.FrequencyAxis.CalculateTrueFrequencies();
+            cosCWT.FrequencyAxis.CalculateMZValues();            
             var nulledCWTFrequencies = new CWTFrequencies();
             Assert.Throws<NullReferenceException>(() => nulledCWTFrequencies.CalculateIndicesForFrequencyRange(0.8, 1.4));
             Assert.Throws<ArgumentException>(() => cosCWT.FrequencyAxis.CalculateIndicesForFrequencyRange(0.01, 2));
@@ -84,6 +86,13 @@ namespace TestFCWTAPI
             var endindexRange = cosCWT.FrequencyAxis.CalculateIndicesForFrequencyRange(3.1199, 3.13);
             Assert.AreEqual(1198, endindexRange.Item1);
             Assert.AreEqual(1199, endindexRange.Item2);
+            var mzIndexRange = cosCWT.FrequencyAxis.CalculateIndicesForFrequencyRange(309108.469, 294468.634, CWTFrequencies.FrequencyUnits.MZValues);
+            Assert.AreEqual(1, mzIndexRange.Item1);
+            Assert.AreEqual(9, mzIndexRange.Item2);
+            var trueFrequencyRange = cosCWT.FrequencyAxis.CalculateIndicesForFrequencyRange(4925.781, 5242.714, CWTFrequencies.FrequencyUnits.TrueFrequency);
+            Assert.AreEqual(1, trueFrequencyRange.Item1);
+            Assert.AreEqual(19, trueFrequencyRange.Item2);
+
 
 
         }        
@@ -121,7 +130,8 @@ namespace TestFCWTAPI
             var cwtFrequencies = new CWTFrequencies(testFrequencies, testNbVoices, testSampleRate, testCalibrationCoefficient);
             var noCalibration = new CWTFrequencies(testFrequencies, testNbVoices, testSampleRate);
             Assert.Throws<NullReferenceException>(() => noCalibration.MZValueToWaveletFreq(testTrueFrequency));
-            Assert.AreEqual(cwtFrequencies.TrueFreqToWaveletFreq(testTrueFrequency), testWaveletFrequency);
+            double waveletFrequency = cwtFrequencies.TrueFreqToWaveletFreq(testTrueFrequency);
+            Assert.AreEqual(waveletFrequency, testWaveletFrequency);
         }
     }
 }


### PR DESCRIPTION
Added functionality to the CWTFrequencies object to use frequency axes containing both M/Z values and the true frequencies from data. Additionally, dependent methods such as plotting methods were adapted to use these new values. The plotting functionality will need to be changed to accommodate these new axes in terms of getting correct units and using the proper axis orientations.