### PR TITLE
Time axis compression

### DIFF
--- a/FCWTAPI/CWTExtensions.cs
+++ b/FCWTAPI/CWTExtensions.cs
@@ -24,8 +24,8 @@ namespace FCWTNET
         /// Compresses the original double[,] to be the largest array with less columns than maxArrayColumns
         /// with the same number of rows as the original array.
         /// </summary>
-        /// <param name="data">Original double[]</param>
-        /// <param name="compressedData">Output double[]</param>
+        /// <param name="data">Original double[,]</param>
+        /// <param name="compressedData">Output double[,]</param>
         /// <param name="maxArrayColumns">Maximum number of columns in the output array</param>
         public static void Time2DArrayCompression(double[,] data, out double[,] compressedData, int maxArrayColumns)
         {
@@ -61,8 +61,8 @@ namespace FCWTNET
         /// Method for compressing CWT time axis.
         /// Compresses the original double[] to be the largest array with less elements than maxArrayColumns
         /// </summary>
-        /// <param name="data">Original double[,]</param>
-        /// <param name="compressedData">Output double[,]</param>
+        /// <param name="data">Original double[]</param>
+        /// <param name="compressedData">Output double[]</param>
         /// <param name="maxArrayColumns">Maximum number of elements in the output array</param>
         public static void TimeAxisCompression(double[] data, out double[] compressedData, int maxArrayColumns)
         {

--- a/FCWTAPI/CWTExtensions.cs
+++ b/FCWTAPI/CWTExtensions.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace FCWTNET
 {
-    public static  class CWTExtensions
+    public static class CWTExtensions
     {
         public static double GetFrequencyAtIndex(this CWTObject cwt, int index)
         {
@@ -16,8 +16,80 @@ namespace FCWTNET
             }
             else
             {
-                throw new NullReferenceException("cwt frequency axis is null"); 
+                throw new NullReferenceException("cwt frequency axis is null");
             }
+        }
+        /// <summary>
+        /// Method for compressing CWT features along the time axis.
+        /// Compresses the original double[,] to be the largest array with less columns than maxArrayColumns
+        /// with the same number of rows as the original array.
+        /// </summary>
+        /// <param name="data">Original double[]</param>
+        /// <param name="compressedData">Output double[]</param>
+        /// <param name="maxArrayColumns">Maximum number of columns in the output array</param>
+        public static void Time2DArrayCompression(double[,] data, out double[,] compressedData, int maxArrayColumns)
+        {
+            if (maxArrayColumns <= 0)
+            {
+                throw new ArgumentException("maxArrayColumns must be a positive integer", nameof(maxArrayColumns));
+            }
+            int compressionRatio = (int)Math.Ceiling(data.GetLength(1) / (double)maxArrayColumns);
+            int subDvisionCount = (int)Math.Ceiling((double)data.GetLength(1) / compressionRatio);
+            compressedData = new double[data.GetLength(0), subDvisionCount];
+            for (int i = 0; i < data.GetLength(0); i++)
+            {
+                for (int j = 0; j < subDvisionCount - 1; j++)
+                {
+                    double pointSum = 0;
+                    for (int k = 0; k < compressionRatio; k++)
+                    {
+                        pointSum += data[i, compressionRatio * j + k];
+                    }
+                    compressedData[i, j] = pointSum / compressionRatio;
+                }
+                double finalPointSum = 0;
+                double finalPointCount = 0;
+                for (int j = (subDvisionCount - 1) * compressionRatio; j < data.GetLength(1); j++)
+                {
+                    finalPointSum += data[i, j];
+                    finalPointCount += 1;
+                }
+                compressedData[i, compressedData.GetLength(1) - 1] = finalPointSum / finalPointCount;
+            }
+        }
+        /// <summary>
+        /// Method for compressing CWT time axis.
+        /// Compresses the original double[] to be the largest array with less elements than maxArrayColumns
+        /// </summary>
+        /// <param name="data">Original double[,]</param>
+        /// <param name="compressedData">Output double[,]</param>
+        /// <param name="maxArrayColumns">Maximum number of elements in the output array</param>
+        public static void TimeAxisCompression(double[] data, out double[] compressedData, int maxArrayColumns)
+        {
+            if (maxArrayColumns <= 0)
+            {
+                throw new ArgumentException("maxArrayColumns must be a positive integer", nameof(maxArrayColumns));
+            }
+            int compressionRatio = (int)Math.Ceiling(data.Length / (double)maxArrayColumns);
+            int subDvisionCount = (int)Math.Ceiling((double)data.Length / compressionRatio);
+            compressedData = new double[subDvisionCount];
+            for (int j = 0; j < subDvisionCount - 1; j++)
+            {
+                double pointSum = 0;
+                for (int k = 0; k < compressionRatio; k++)
+                {
+                    pointSum += data[compressionRatio * j + k];
+                }
+                compressedData[j] = pointSum / compressionRatio;
+            }
+            double finalPointSum = 0;
+            double finalPointCount = 0;
+            for (int j = (subDvisionCount - 1) * compressionRatio; j < data.Length; j++)
+            {
+                finalPointSum += data[j];
+                finalPointCount += 1;
+            }
+            compressedData[compressedData.Length - 1] = finalPointSum / finalPointCount;
         }
     }
 }

--- a/FCWTAPI/CWTObject.cs
+++ b/FCWTAPI/CWTObject.cs
@@ -169,6 +169,17 @@ namespace FCWTNET
             {
                 data = OutputCWT.PhaseCalculation();
             }
+            // Section to compress time axis for large data plotting
+            int maxColumns = 100000;
+            double[,] finalData;
+            if (data.GetLength(1) >= maxColumns)
+            {
+                CWTExtensions.Time2DArrayCompression(data, out finalData, maxColumns);
+            }
+            else
+            {
+                finalData = data;
+            }
             string title;
             if (cwtFeature == CWTFeatures.Imaginary || cwtFeature == CWTFeatures.Real)
             {
@@ -183,18 +194,18 @@ namespace FCWTNET
                 title = dataName + title;
             }
             // Reflects data about the xy axis to plot CWT data with Freqeuncy in the y-axis and time in the x-axis
-            double[,] xyReflectedData = new double[data.GetLength(1), data.GetLength(0)];
-            for (int i = 0; i < data.GetLength(0); i++)
+            double[,] xyReflectedData = new double[finalData.GetLength(1), finalData.GetLength(0)];
+            for (int i = 0; i < finalData.GetLength(0); i++)
             {
-                for (int j = 0; j < data.GetLength(1); j++)
+                for (int j = 0; j < finalData.GetLength(1); j++)
                 {
-                    xyReflectedData[j, i] = data[i, j];
+                    xyReflectedData[j, i] = finalData[i, j];
                 }
             }
             PlotModel cwtPlot = PlottingUtils.GenerateCWTHeatMap(xyReflectedData, title, TimeAxis, FrequencyAxis.WaveletCenterFrequencies);
             string filePath = Path.Combine(WorkingPath, fileName);
             PlottingUtils.ExportPlotPDF(cwtPlot, filePath);
-        }
+        }      
 
         /// <summary>
         /// Method to generate different 2D XY Plots from the CWT along frequency bands
@@ -306,6 +317,19 @@ namespace FCWTNET
                 int frequencyIndex = rawFrequencyIndex < 0 ? -rawFrequencyIndex + 1 : rawFrequencyIndex;
                 indFrequencies = new int[] {frequencyIndex};
             }
+            int maxColumns = 100000;
+            double[,] finalData;
+            double[] finalTimeAxis;
+            if (data.GetLength(1) >= maxColumns)
+            {
+                CWTExtensions.Time2DArrayCompression(data, out finalData, maxColumns);
+                CWTExtensions.TimeAxisCompression(TimeAxis, out finalTimeAxis, maxColumns);
+            }
+            else
+            {
+                finalData = data;
+                finalTimeAxis = TimeAxis;
+            }
             double[,] xyReflectedData = new double[data.GetLength(1), data.GetLength(0)];
             for (int i = 0; i < data.GetLength(0); i++)
             {
@@ -314,7 +338,7 @@ namespace FCWTNET
                     xyReflectedData[j, i] = data[i, j];
                 }
             }
-            PlotModel cwtPlot = PlottingUtils.GenerateXYPlotCWT(xyReflectedData, indFrequencies, TimeAxis, FrequencyAxis.WaveletCenterFrequencies, PlottingUtils.PlotTitles.Custom, plotMode, title);
+            PlotModel cwtPlot = PlottingUtils.GenerateXYPlotCWT(xyReflectedData, indFrequencies, finalTimeAxis, FrequencyAxis.WaveletCenterFrequencies, PlottingUtils.PlotTitles.Custom, plotMode, title);
 
             string filePath = Path.Combine(WorkingPath, fileName);
             PlottingUtils.ExportPlotPDF(cwtPlot, filePath);

--- a/TestFCWTAPI/CWTExtensionsTests.cs
+++ b/TestFCWTAPI/CWTExtensionsTests.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using FCWTNET;
+
+namespace TestFCWTAPI
+{
+    public class CWTExtensionsTests
+    {
+        [Test]
+        public static void TestTime2DArrayCompression()
+        {
+            double[,] testData = new double[,]
+            {
+                {1, 2, 3, 4, 5, 6, 7, 8, 9, 10 },
+                {1, 2, 3, 4, 5, 6, 7, 8, 9, 10 },
+                {1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }
+            };
+            double perfectDivTestPoint = (3D + 4D) / 2D;
+            double rem2DivTestEdgePoint = (9D + 10D) / 2D;
+            double primeMaxSizeTestPoint = (5D + 6D + 7D + 8D) / 4D;
+            double[,] perfectDivision;
+            double[,] rem2Division;
+            double[,] emptyArray;
+            CWTExtensions.Time2DArrayCompression(testData, out perfectDivision, 5);
+            CWTExtensions.Time2DArrayCompression(testData, out rem2Division, 3);
+            Assert.Throws<ArgumentException>(() => CWTExtensions.Time2DArrayCompression(testData, out emptyArray, -5));
+            Assert.AreEqual(perfectDivTestPoint, perfectDivision[0, 1], 0.001);
+            Assert.AreEqual(rem2DivTestEdgePoint, rem2Division[0, 2], 0.001);
+            Assert.AreEqual(3, rem2Division.GetLength(1));
+            Assert.AreEqual(5, perfectDivision.GetLength(1));
+        }
+        [Test]
+        public static void TestTimeAxisCompression()
+        {
+            double[] testAxis = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+            double perfectDivTestPoint = (3D + 4D) / 2D;
+            double rem2DivTestEdgePoint = (9D + 10D) / 2D;
+            double[] compressedPerfectDivAxis;
+            double[] compressedRem2Axis;
+            double[] emptyArray;
+            CWTExtensions.TimeAxisCompression(testAxis, out compressedRem2Axis, 3);
+            CWTExtensions.TimeAxisCompression(testAxis, out compressedPerfectDivAxis, 5);
+            Assert.Throws<ArgumentException>(() => CWTExtensions.TimeAxisCompression(testAxis, out emptyArray, -5));
+            Assert.AreEqual(3, compressedRem2Axis.Length);
+            Assert.AreEqual(5, compressedPerfectDivAxis.Length);
+            Assert.AreEqual(perfectDivTestPoint, compressedPerfectDivAxis[1]);
+            Assert.AreEqual(rem2DivTestEdgePoint, compressedRem2Axis[2]);
+
+        }
+    }
+}


### PR DESCRIPTION
Added functionality to compress CWT along the time axis to allow for the plotting of transients with many timepoints.